### PR TITLE
refactor: port over lifecycle improvements from cache branch

### DIFF
--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -1,0 +1,18 @@
+//
+//  PlayerSDK.swift
+//
+
+import Foundation
+
+// internal class to manage dependency injection
+class PlayerSDK {
+
+    static let shared = PlayerSDK()
+
+    let monitor: Monitor
+
+    init() {
+        self.monitor = Monitor()
+    }
+
+}

--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -7,7 +7,11 @@ import Foundation
 // internal class to manage dependency injection
 class PlayerSDK {
 
+    #if DEBUG
+    static var shared = PlayerSDK()
+    #else
     static let shared = PlayerSDK()
+    #endif
 
     let monitor: Monitor
 

--- a/Sources/MuxPlayerSwift/Monitoring/Monitor.swift
+++ b/Sources/MuxPlayerSwift/Monitoring/Monitor.swift
@@ -16,8 +16,6 @@ class Monitor {
         var binding: MUXSDKPlayerBinding
     }
 
-    static let shared = Monitor()
-
     var bindings: [ObjectIdentifier: MonitoredPlayer] = [:]
 
     func setupMonitoring(

--- a/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerLayer+Mux.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerLayer+Mux.swift
@@ -25,7 +25,7 @@ extension AVPlayerLayer {
             playbackID: playbackID
         )
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerLayer: self,
             options: monitoringOptions
         )
@@ -58,7 +58,7 @@ extension AVPlayerLayer {
             playbackID: playbackID
         )
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerLayer: self,
             options: monitoringOptions
         )
@@ -90,7 +90,7 @@ extension AVPlayerLayer {
 
         self.player = player
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerLayer: self,
             options: monitoringOptions
         )
@@ -98,7 +98,7 @@ extension AVPlayerLayer {
 
     /// Stops monitoring the player
     public func stopMonitoring() {
-        Monitor.shared.tearDownMonitoring(playerLayer: self)
+        PlayerSDK.shared.monitor.tearDownMonitoring(playerLayer: self)
     }
     
 
@@ -218,7 +218,7 @@ extension AVPlayerLayer {
             )
         }
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerLayer: self,
             options: monitoringOptions
         )

--- a/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerViewController+Mux.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerViewController+Mux.swift
@@ -25,7 +25,7 @@ extension AVPlayerViewController {
             playbackID: playbackID
         )
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerViewController: self,
             options: monitoringOptions
         )
@@ -51,7 +51,7 @@ extension AVPlayerViewController {
 
         self.player = player
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerViewController: self,
             options: monitoringOptions
         )
@@ -84,7 +84,7 @@ extension AVPlayerViewController {
             playbackID: playbackID
         )
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerViewController: self,
             options: monitoringOptions
         )
@@ -116,7 +116,7 @@ extension AVPlayerViewController {
 
         self.player = player
 
-        Monitor.shared.setupMonitoring(
+        PlayerSDK.shared.monitor.setupMonitoring(
             playerViewController: self,
             options: monitoringOptions
         )
@@ -124,7 +124,7 @@ extension AVPlayerViewController {
 
     /// Stops monitoring the player
     public func stopMonitoring() {
-        Monitor.shared.tearDownMonitoring(playerViewController: self)
+        PlayerSDK.shared.monitor.tearDownMonitoring(playerViewController: self)
     }
 
 }

--- a/Tests/MuxPlayerSwift/MonitorTests.swift
+++ b/Tests/MuxPlayerSwift/MonitorTests.swift
@@ -27,7 +27,7 @@ class MonitorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        Monitor.shared.bindings.removeAll()
+        PlayerSDK.shared.monitor.bindings.removeAll()
     }
 
     func testPlayerViewControllerMonitoringLifecycle() throws {
@@ -36,7 +36,7 @@ class MonitorTests: XCTestCase {
             playbackID: "abc"
         )
 
-        let monitor = Monitor.shared
+        let monitor = PlayerSDK.shared.monitor
 
         XCTAssertEqual(
             monitor.bindings.count,
@@ -57,7 +57,7 @@ class MonitorTests: XCTestCase {
             playbackID: "abc"
         )
 
-        let monitor = Monitor.shared
+        let monitor = PlayerSDK.shared.monitor
 
         XCTAssertEqual(
             monitor.bindings.count,
@@ -84,7 +84,7 @@ class MonitorTests: XCTestCase {
             playbackID: "abc"
         )
 
-        let monitor = Monitor.shared
+        let monitor = PlayerSDK.shared.monitor
 
         XCTAssertEqual(
             monitor.bindings.count,


### PR DESCRIPTION
PlayerSDK is intended to be the root of the SDKs object graph