### PR TITLE
feat: instant clipping based on relative asset time

### DIFF
--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -48,44 +48,67 @@ class SinglePlayerExampleController: UIViewController {
 
     var minimumResolutionTier: MinResolutionTier = .default {
         didSet {
-            playerViewController.prepare(
-                playbackID: playbackID,
-                playbackOptions: PlaybackOptions(
-                    maximumResolutionTier: maximumResolutionTier,
-                    minimumResolutionTier: minimumResolutionTier,
-                    renditionOrder: renditionOrder
-                ),
-                monitoringOptions: monitoringOptions
-            )
+            preparePlayerViewController()
         }
     }
 
     var maximumResolutionTier: MaxResolutionTier = .default {
         didSet {
-            playerViewController.prepare(
-                playbackID: playbackID,
-                playbackOptions: PlaybackOptions(
-                    maximumResolutionTier: maximumResolutionTier,
-                    minimumResolutionTier: minimumResolutionTier,
-                    renditionOrder: renditionOrder
-                ),
-                monitoringOptions: monitoringOptions
-            )
+            preparePlayerViewController()
         }
     }
 
     var renditionOrder: RenditionOrder = .default {
         didSet {
-            playerViewController.prepare(
-                playbackID: playbackID,
-                playbackOptions: PlaybackOptions(
-                    maximumResolutionTier: maximumResolutionTier,
-                    minimumResolutionTier: minimumResolutionTier,
-                    renditionOrder: renditionOrder
-                ),
-                monitoringOptions: monitoringOptions
-            )
+            preparePlayerViewController()
         }
+    }
+
+    var assetStartTimeInSeconds: UInt? {
+        didSet {
+            preparePlayerViewController()
+        }
+    }
+
+
+    var assetEndTimeInSeconds: UInt? {
+        didSet {
+            preparePlayerViewController()
+        }
+    }
+
+    func preparePlayerViewController() {
+
+        let instantClipping: InstantClipping
+
+        switch (assetStartTimeInSeconds, assetEndTimeInSeconds) {
+            case (.none, .none):
+                instantClipping = .none
+            case (.some(let clipStartTime), .none):
+                instantClipping = InstantClipping(
+                    assetStartTimeInSeconds: clipStartTime
+                )
+            case (.none, .some(let clipEndTime)):
+                instantClipping = InstantClipping(
+                    assetEndTimeInSeconds: clipEndTime
+                )
+            case (.some(let clipStartTime), .some(let clipEndTime)):
+                instantClipping = InstantClipping(
+                    assetStartTimeInSeconds: clipStartTime,
+                    assetEndTimeInSeconds: clipEndTime
+                )
+        }
+
+        playerViewController.prepare(
+            playbackID: playbackID,
+            playbackOptions: PlaybackOptions(
+                maximumResolutionTier: maximumResolutionTier,
+                minimumResolutionTier: minimumResolutionTier,
+                renditionOrder: renditionOrder,
+                clipping: instantClipping
+            ),
+            monitoringOptions: monitoringOptions
+        )
     }
 
     // MARK: Status Bar Appearance
@@ -99,133 +122,286 @@ class SinglePlayerExampleController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .black
         view.accessibilityLabel = "A single player example that uses AVPlayerViewController"
         view.accessibilityIdentifier = "SinglePlayerView"
 
-        let maximumResolutionsMenu = UIMenu(
-            title: "Set Maximum Resolution",
-            children: [
-                UIAction(
-                    title: "Default",
-                    handler: { _ in
-                        self.maximumResolutionTier = .default
-                    }
-                ),
-                UIAction(
-                    title: "Up to 720p",
-                    handler: { _ in
-                        self.maximumResolutionTier = .upTo720p
-                    }
-                ),
-                UIAction(
-                    title: "Up to 1080p",
-                    handler: { _ in
-                        self.maximumResolutionTier = .upTo1080p
-                    }
-                ),
-                UIAction(
-                    title: "Up to 1440p",
-                    handler: { _ in
-                        self.maximumResolutionTier = .upTo1440p
-                    }
-                ),
-                UIAction(
-                    title: "Up to 2160p",
-                    handler: { _ in
-                        self.maximumResolutionTier = .upTo2160p
-                    }
-                )
-            ]
+        let maximumResolutionSelectionControl = UISegmentedControl()
+
+        let defaultMaxResolutionAction = UIAction(
+            title: "Default"
+        ) { _ in
+            self.maximumResolutionTier = .default
+        }
+
+        maximumResolutionSelectionControl.insertSegment(
+            action: defaultMaxResolutionAction,
+            at: 0,
+            animated: false
         )
 
-        let minimumResolutionsMenu = UIMenu(
-            title: "Set Minimum Resolution",
-            children: [
-                UIAction(
-                    title: "Default",
-                    handler: { _ in
-                        self.minimumResolutionTier = .default
-                    }
-                ),
-                UIAction(
-                    title: "At least 480p",
-                    handler: { _ in
-                        self.minimumResolutionTier = .atLeast480p
-                    }
-                ),
-                UIAction(
-                    title: "At least 540p",
-                    handler: { _ in
-                        self.minimumResolutionTier = .atLeast540p
-                    }
-                ),
-                UIAction(
-                    title: "At least 720p",
-                    handler: { _ in
-                        self.minimumResolutionTier = .atLeast720p
-                    }
-                ),
-                UIAction(
-                    title: "At least 1080p",
-                    handler: { _ in
-                        self.minimumResolutionTier = .atLeast1080p
-                    }
-                ),
-                UIAction(
-                    title: "At least 1440p",
-                    handler: { _ in
-                        self.minimumResolutionTier = .atLeast1440p
-                    }
-                ),
-                UIAction(
-                    title: "At least 2160p",
-                    handler: { _ in
-                        self.minimumResolutionTier = .atLeast2160p
-                    }
-                ),
-            ]
+        let upTo720pAction = UIAction(
+            title: "Up to 720p"
+        ) { _ in
+            self.maximumResolutionTier = .upTo720p
+        }
+
+        maximumResolutionSelectionControl.insertSegment(
+            action: upTo720pAction,
+            at: 1,
+            animated: false
         )
 
-        let renditionOrderMenu = UIMenu(
-            title: "Set Rendition Order",
-            children: [
-                UIAction(
-                    title: "Default",
-                    handler: { _ in
-                        self.renditionOrder = .default
-                    }
-                ),
-                UIAction(
-                    title: "Descending",
-                    handler: { _ in
-                        self.renditionOrder = .descending
-                    }
-                ),
-            ]
+        let upTo1080pAction = UIAction(
+            title: "Up to 1080p"
+        ) { _ in
+            self.maximumResolutionTier = .upTo1080p
+        }
+
+        maximumResolutionSelectionControl.insertSegment(
+            action: upTo1080pAction,
+            at: 2,
+            animated: false
         )
 
-        let optionsMenu = UIMenu(
-            children: [
-                maximumResolutionsMenu,
-                minimumResolutionsMenu,
-                renditionOrderMenu
-            ]
+        let upTo1440pAction = UIAction(
+            title: "Up to 1440p"
+        ) { _ in
+            self.maximumResolutionTier = .upTo1440p
+        }
+
+        maximumResolutionSelectionControl.insertSegment(
+            action: upTo1440pAction,
+            at: 3,
+            animated: false
         )
 
+        let upTo2160pAction = UIAction(
+            title: "Up to 2160p"
+        ) { _ in
+            self.maximumResolutionTier = .upTo2160p
+        }
+
+        maximumResolutionSelectionControl.insertSegment(
+            action: upTo2160pAction,
+            at: 4,
+            animated: false
+        )
+
+        let minimumResolutionSelectionControl = UISegmentedControl()
+
+        let defaultMinimumResolutionAction = UIAction(
+            title: "Default",
+            handler: { _ in
+                self.minimumResolutionTier = .default
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: defaultMinimumResolutionAction,
+            at: 0,
+            animated: false
+        )
+
+        let atLeast480pAction = UIAction(
+            title: "At least 480p",
+            handler: { _ in
+                self.minimumResolutionTier = .atLeast480p
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: atLeast480pAction,
+            at: 1,
+            animated: false
+        )
+
+        let atLeast540pAction = UIAction(
+            title: "At least 540p",
+            handler: { _ in
+                self.minimumResolutionTier = .atLeast540p
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: atLeast540pAction,
+            at: 2,
+            animated: false
+        )
+
+        let atLeast720pAction = UIAction(
+            title: "At least 720p",
+            handler: { _ in
+                self.minimumResolutionTier = .atLeast720p
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: atLeast720pAction,
+            at: 3,
+            animated: false
+        )
+
+        let atLeast1080pAction = UIAction(
+            title: "At least 1080p",
+            handler: { _ in
+                self.minimumResolutionTier = .atLeast1080p
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: atLeast1080pAction,
+            at: 4,
+            animated: false
+        )
+
+        let atLeast1440pAction = UIAction(
+            title: "At least 1440p",
+            handler: { _ in
+                self.minimumResolutionTier = .atLeast1440p
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: atLeast1440pAction,
+            at: 5,
+            animated: false
+        )
+
+        let atLeast2160pAction = UIAction(
+            title: "At least 2160p",
+            handler: { _ in
+                self.minimumResolutionTier = .atLeast2160p
+            }
+        )
+
+        minimumResolutionSelectionControl.insertSegment(
+            action: atLeast2160pAction,
+            at: 6,
+            animated: false
+        )
+
+        let renditionOrderSelectionControl = UISegmentedControl()
+
+        let defaultRenditionOrderAction = UIAction(
+            title: "Default",
+            handler: { _ in
+                self.renditionOrder = .default
+            }
+        )
+
+        renditionOrderSelectionControl.insertSegment(
+            action: defaultRenditionOrderAction,
+            at: 0,
+            animated: false
+        )
+
+        let descendingRenditionOrderAction = UIAction(
+            title: "Descending",
+            handler: { _ in
+                self.renditionOrder = .descending
+            }
+        )
+
+        renditionOrderSelectionControl.insertSegment(
+            action: descendingRenditionOrderAction,
+            at: 1,
+            animated: false
+        )
+
+        let maximumResolutionLabel = UILabel()
+        maximumResolutionLabel.textAlignment = .center
+        maximumResolutionLabel.text = "Maximum Resolution"
+
+        let minimumResolutionLabel = UILabel()
+        minimumResolutionLabel.textAlignment = .center
+        minimumResolutionLabel.text = "Minimum Resolution"
+
+        let renditionOrderLabel = UILabel()
+        renditionOrderLabel.textAlignment = .center
+        renditionOrderLabel.text = "Rendition Order"
+
+        maximumResolutionSelectionControl.selectedSegmentIndex = 0
+
+        minimumResolutionSelectionControl.selectedSegmentIndex = 0
+
+        renditionOrderSelectionControl.selectedSegmentIndex = 0
+
+        let assetStartTimeTextField = UITextField(
+            frame: .zero,
+            primaryAction: UIAction(
+                handler: { action in
+                    if let text = (action.sender as? UITextField)?.text {
+                        self.assetStartTimeInSeconds = (
+                            try? UInt(
+                                text,
+                                format: .number
+                            )
+                        ) ?? nil
+                    }
+                }
+            )
+        )
+        assetStartTimeTextField.keyboardType = .decimalPad
+        assetStartTimeTextField.placeholder = "Clip starting time if desired"
+
+        let assetEndTimeTextField = UITextField(
+            frame: .zero,
+            primaryAction: UIAction(
+                handler: { action in
+                    if let text = (action.sender as? UITextField)?.text {
+                        self.assetEndTimeInSeconds = (
+                            try? UInt(
+                                text,
+                                format: .number
+                            )
+                        ) ?? nil
+                    }
+                }
+            )
+        )
+        assetEndTimeTextField.keyboardType = .decimalPad
+        assetEndTimeTextField.placeholder = "Clip ending time if desired"
+
+        let stackView = UIStackView(
+            arrangedSubviews: [
+                maximumResolutionLabel,
+                maximumResolutionSelectionControl,
+                minimumResolutionLabel,
+                minimumResolutionSelectionControl,
+                renditionOrderLabel,
+                renditionOrderSelectionControl,
+                assetStartTimeTextField,
+                assetEndTimeTextField
+            ]
+        )
+        stackView.axis = .vertical
+        stackView.spacing = 25.0
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+
+        view.addConstraints([
+            stackView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: 30.0
+            ),
+            stackView.widthAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.widthAnchor,
+                multiplier: 0.9
+            ),
+            stackView.centerXAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.centerXAnchor
+            )
+        ])
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "Adjust SDK Options",
-            menu: optionsMenu
+            title: "Play Video",
+            primaryAction: UIAction(
+                handler: { _ in
+                    self.displayPlayerViewController()
+                }
+            )
         )
-
-        displayPlayerViewController()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        self.playerViewController.player?.play()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -237,32 +413,18 @@ class SinglePlayerExampleController: UIViewController {
     // MARK: Player Lifecycle
 
     func displayPlayerViewController() {
-        playerViewController.willMove(toParent: self)
-        addChild(playerViewController)
-        view.addSubview(playerViewController.view)
-        playerViewController.didMove(toParent: self)
-        playerViewController
-            .view
-            .translatesAutoresizingMaskIntoConstraints = false
-        view.addConstraints([
-            playerViewController.view.leadingAnchor.constraint(
-                equalTo: view.leadingAnchor
-            ),
-            playerViewController.view.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor
-            ),
-            playerViewController.view.layoutMarginsGuide.topAnchor.constraint(
-                equalTo: view.topAnchor
-            ),
-            playerViewController.view.layoutMarginsGuide.bottomAnchor
-                .constraint(equalTo: view.bottomAnchor),
-        ])
+        present(
+            playerViewController,
+            animated: true
+        ) {
+            self.playerViewController.player?.play()
+        }
     }
 
     func hidePlayerViewController() {
-        playerViewController.willMove(toParent: nil)
-        playerViewController.view.removeFromSuperview()
-        playerViewController.removeFromParent()
+        dismiss(
+            animated: true
+        )
     }
 
 }

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -64,48 +64,30 @@ class SinglePlayerExampleController: UIViewController {
         }
     }
 
-    var assetStartTimeInSeconds: UInt? {
+    var assetStartTimeInSeconds: Double = .nan {
         didSet {
             preparePlayerViewController()
         }
     }
 
 
-    var assetEndTimeInSeconds: UInt? {
+    var assetEndTimeInSeconds: Double = .nan {
         didSet {
             preparePlayerViewController()
         }
     }
 
     func preparePlayerViewController() {
-
-        let instantClipping: InstantClipping
-
-        switch (assetStartTimeInSeconds, assetEndTimeInSeconds) {
-            case (.none, .none):
-                instantClipping = .none
-            case (.some(let clipStartTime), .none):
-                instantClipping = InstantClipping(
-                    assetStartTimeInSeconds: clipStartTime
-                )
-            case (.none, .some(let clipEndTime)):
-                instantClipping = InstantClipping(
-                    assetEndTimeInSeconds: clipEndTime
-                )
-            case (.some(let clipStartTime), .some(let clipEndTime)):
-                instantClipping = InstantClipping(
-                    assetStartTimeInSeconds: clipStartTime,
-                    assetEndTimeInSeconds: clipEndTime
-                )
-        }
-
         playerViewController.prepare(
             playbackID: playbackID,
             playbackOptions: PlaybackOptions(
                 maximumResolutionTier: maximumResolutionTier,
                 minimumResolutionTier: minimumResolutionTier,
                 renditionOrder: renditionOrder,
-                clipping: instantClipping
+                clipping: InstantClipping(
+                    assetStartTimeInSeconds: assetStartTimeInSeconds,
+                    assetEndTimeInSeconds: assetEndTimeInSeconds
+                )
             ),
             monitoringOptions: monitoringOptions
         )
@@ -332,11 +314,11 @@ class SinglePlayerExampleController: UIViewController {
                 handler: { action in
                     if let text = (action.sender as? UITextField)?.text {
                         self.assetStartTimeInSeconds = (
-                            try? UInt(
+                            try? Double(
                                 text,
                                 format: .number
                             )
-                        ) ?? nil
+                        ) ?? .nan
                     }
                 }
             )
@@ -350,11 +332,11 @@ class SinglePlayerExampleController: UIViewController {
                 handler: { action in
                     if let text = (action.sender as? UITextField)?.text {
                         self.assetEndTimeInSeconds = (
-                            try? UInt(
+                            try? Double(
                                 text,
                                 format: .number
                             )
-                        ) ?? nil
+                        ) ?? .nan
                     }
                 }
             )

--- a/Sources/MuxPlayerSwift/InternalExtensions/URLComponents+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/URLComponents+Mux.swift
@@ -59,6 +59,26 @@ internal extension URLComponents {
                 )
             }
 
+            if publicPlaybackOptions.instantClipping.noInstantClipping == false {
+                if let assetStartTimeInSeconds = publicPlaybackOptions.instantClipping.assetStartTimeInSeconds {
+                    queryItems.append(
+                        URLQueryItem(
+                            name: "asset_start_time",
+                            value: assetStartTimeInSeconds.description
+                        )
+                    )
+                }
+
+                if let assetEndTimeInSeconds = publicPlaybackOptions.instantClipping.assetEndTimeInSeconds {
+                    queryItems.append(
+                        URLQueryItem(
+                            name: "asset_end_time",
+                            value: assetEndTimeInSeconds.description
+                        )
+                    )
+                }
+            }
+
             self.queryItems = queryItems
 
         } else if case PlaybackOptions.PlaybackPolicy.signed(let signedPlaybackOptions) = playbackOptions.playbackPolicy {

--- a/Sources/MuxPlayerSwift/InternalExtensions/URLComponents+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/URLComponents+Mux.swift
@@ -60,20 +60,20 @@ internal extension URLComponents {
             }
 
             if publicPlaybackOptions.instantClipping.noInstantClipping == false {
-                if let assetStartTimeInSeconds = publicPlaybackOptions.instantClipping.assetStartTimeInSeconds {
+                if !publicPlaybackOptions.instantClipping.assetStartTimeInSeconds.isNaN {
                     queryItems.append(
                         URLQueryItem(
                             name: "asset_start_time",
-                            value: assetStartTimeInSeconds.description
+                            value: publicPlaybackOptions.instantClipping.assetStartTimeInSeconds.description
                         )
                     )
                 }
 
-                if let assetEndTimeInSeconds = publicPlaybackOptions.instantClipping.assetEndTimeInSeconds {
+                if !publicPlaybackOptions.instantClipping.assetEndTimeInSeconds.isNaN {
                     queryItems.append(
                         URLQueryItem(
                             name: "asset_end_time",
-                            value: assetEndTimeInSeconds.description
+                            value: publicPlaybackOptions.instantClipping.assetEndTimeInSeconds.description
                         )
                     )
                 }

--- a/Sources/MuxPlayerSwift/PublicAPI/Options/PlaybackOptions.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Options/PlaybackOptions.swift
@@ -79,9 +79,12 @@ public enum SingleRenditionResolutionTier {
 /// Available for all video on-demand assets.
 public struct InstantClipping: Equatable {
 
-    let noInstantClipping: Bool
     var assetStartTimeInSeconds: UInt?
     var assetEndTimeInSeconds: UInt?
+
+    var noInstantClipping: Bool {
+        return self.assetStartTimeInSeconds == nil && self.assetEndTimeInSeconds == nil
+    }
 
     /// Omits instant clipping when loading a playback ID.
     public static let none = InstantClipping()
@@ -89,7 +92,6 @@ public struct InstantClipping: Equatable {
     init() {
         self.assetStartTimeInSeconds = nil
         self.assetEndTimeInSeconds = nil
-        self.noInstantClipping = true
     }
 
     /// Streams a clip whose starting time are based on
@@ -123,7 +125,6 @@ public struct InstantClipping: Equatable {
     ) {
         self.assetStartTimeInSeconds = assetStartTimeInSeconds
         self.assetEndTimeInSeconds = assetEndTimeInSeconds
-        self.noInstantClipping = false
     }
 
     /// Streams a clip whose starting time is based on
@@ -139,7 +140,6 @@ public struct InstantClipping: Equatable {
     ) {
         self.assetStartTimeInSeconds = assetStartTimeInSeconds
         self.assetEndTimeInSeconds = nil
-        self.noInstantClipping = false
     }
 
     /// Streams a clip with an ending time based on the
@@ -154,7 +154,6 @@ public struct InstantClipping: Equatable {
     ) {
         self.assetStartTimeInSeconds = nil
         self.assetEndTimeInSeconds = assetEndTimeInSeconds
-        self.noInstantClipping = false
     }
 }
 

--- a/Sources/MuxPlayerSwift/PublicAPI/Options/PlaybackOptions.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Options/PlaybackOptions.swift
@@ -79,19 +79,19 @@ public enum SingleRenditionResolutionTier {
 /// Available for all video on-demand assets.
 public struct InstantClipping: Equatable {
 
-    var assetStartTimeInSeconds: UInt?
-    var assetEndTimeInSeconds: UInt?
+    var assetStartTimeInSeconds: Double
+    var assetEndTimeInSeconds: Double
 
     var noInstantClipping: Bool {
-        return self.assetStartTimeInSeconds == nil && self.assetEndTimeInSeconds == nil
+        return self.assetStartTimeInSeconds.isNaN && self.assetEndTimeInSeconds.isNaN
     }
 
     /// Omits instant clipping when loading a playback ID.
     public static let none = InstantClipping()
 
     init() {
-        self.assetStartTimeInSeconds = nil
-        self.assetEndTimeInSeconds = nil
+        self.assetStartTimeInSeconds = .nan
+        self.assetEndTimeInSeconds = .nan
     }
 
     /// Streams a clip whose starting time are based on
@@ -120,8 +120,8 @@ public struct InstantClipping: Equatable {
     ///   - assetEndTimeInSeconds: the ending time of
     ///   the clip relative to the asset time
     public init(
-        assetStartTimeInSeconds: UInt,
-        assetEndTimeInSeconds: UInt
+        assetStartTimeInSeconds: Double,
+        assetEndTimeInSeconds: Double
     ) {
         self.assetStartTimeInSeconds = assetStartTimeInSeconds
         self.assetEndTimeInSeconds = assetEndTimeInSeconds
@@ -136,10 +136,10 @@ public struct InstantClipping: Equatable {
     ///   - assetStartTimeInSeconds: the starting time
     ///   of the clip relative to the asset time
     public init(
-        assetStartTimeInSeconds: UInt
+        assetStartTimeInSeconds: Double
     ) {
         self.assetStartTimeInSeconds = assetStartTimeInSeconds
-        self.assetEndTimeInSeconds = nil
+        self.assetEndTimeInSeconds = .nan
     }
 
     /// Streams a clip with an ending time based on the
@@ -150,9 +150,9 @@ public struct InstantClipping: Equatable {
     ///   - assetEndTimeInSeconds: the ending time
     ///   of the clip relative to the asset time
     public init(
-        assetEndTimeInSeconds: UInt
+        assetEndTimeInSeconds: Double
     ) {
-        self.assetStartTimeInSeconds = nil
+        self.assetStartTimeInSeconds = .nan
         self.assetEndTimeInSeconds = assetEndTimeInSeconds
     }
 }

--- a/Tests/MuxPlayerSwift/PlaybackURLTests.swift
+++ b/Tests/MuxPlayerSwift/PlaybackURLTests.swift
@@ -501,4 +501,98 @@ final class PlaybackURLTests: XCTestCase {
             "def456"
         )
     }
+
+    func testClippingAssetStartTime() throws {
+        let item = AVPlayerItem(
+            playbackID: "abc123",
+            playbackOptions: PlaybackOptions(
+                clipping: .init(
+                    assetStartTimeInSeconds: 12
+                )
+            )
+        )
+
+        let url = try XCTUnwrap(
+            (item.asset as? AVURLAsset)?.url,
+            "Expected player item with URL"
+        )
+
+        let queryItems = try XCTUnwrap(
+            URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            )?.queryItems
+        )
+
+        XCTAssertNotNil(
+            queryItems.first(where: {
+                $0.name == "asset_start_time"
+            })
+        )
+    }
+
+    func testClippingAssetEndTime() throws {
+        let item = AVPlayerItem(
+            playbackID: "abc123",
+            playbackOptions: PlaybackOptions(
+                clipping: .init(
+                    assetEndTimeInSeconds: 20
+                )
+            )
+        )
+
+        let url = try XCTUnwrap(
+            (item.asset as? AVURLAsset)?.url,
+            "Expected player item with URL"
+        )
+
+        let queryItems = try XCTUnwrap(
+            URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            )?.queryItems
+        )
+
+        XCTAssertNotNil(
+            queryItems.first(where: {
+                $0.name == "asset_end_time"
+            })
+        )
+    }
+
+    func testClippingAssetStartAndEndTime() throws {
+        let item = AVPlayerItem(
+            playbackID: "abc123",
+            playbackOptions: PlaybackOptions(
+                clipping: .init(
+                    assetStartTimeInSeconds: 12,
+                    assetEndTimeInSeconds: 20
+                )
+            )
+        )
+
+        let url = try XCTUnwrap(
+            (item.asset as? AVURLAsset)?.url,
+            "Expected player item with URL"
+        )
+
+        let queryItems = try XCTUnwrap(
+            URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            )?.queryItems
+        )
+
+        XCTAssertNotNil(
+            queryItems.first(where: {
+                $0.name == "asset_start_time"
+            })
+        )
+
+        XCTAssertNotNil(
+            queryItems.first(where: {
+                $0.name == "asset_end_time"
+            })
+        )
+    }
 }


### PR DESCRIPTION
- [x] expose API to set asset based time parameters for instant clipping
- [x] add controls to set instant clipping if desired to basic playback example panel