### PR TITLE
ci: fix a misplaced 'wait' statement

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,7 @@ steps:
       - "./Examples/MuxPlayerSwiftExample/Packaging.log"
       - "./Examples/MuxPlayerSwiftExample/DistributionSummary.plist"
       - "./Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExampleUITests-Runner.ipa"
+  - wait
   - command: "echo $BUILDKITE_HOOKS_PATH && ls -ls $BUILDKITE_HOOKS_PATH && buildkite-agent artifact download \"Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample.ipa\" \"$PWD\" && buildkite-agent artifact download \"Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExampleUITests-Runner.ipa\" \"$PWD\" && ./scripts/upload-example-application-to-sauce-labs.sh"
     label: ":saucelabs: UI Tests Pass on Real Device"
-  - wait
+


### PR DESCRIPTION
Quick followup for #64 . I swapped a `wait` and a `command` step in the pipeline yaml. This would make the jobs run in parallel, when there is a dependency relationship

This doesn't cause a problem in practice because our iOS queue has only 1 agent. But we shouldn't leave it like this 