### PR TITLE
Proof-of-Concept: Generate short-form manifests

### DIFF
--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -16,9 +16,11 @@ class SinglePlayerExampleController: UIViewController {
 
     // MARK: Player View Controller
 
-    lazy var playerViewController = AVPlayerViewController(
-        playbackID: playbackID
-    )
+    // TODO: aw christ
+    lazy var playerViewController = AVPlayerViewController()
+//    lazy var playerViewController = AVPlayerViewController(
+//        playbackID: playbackID
+//    )
 
     // MARK: Mux Data Monitoring Parameters
 
@@ -398,6 +400,7 @@ class SinglePlayerExampleController: UIViewController {
             title: "Play Video",
             primaryAction: UIAction(
                 handler: { _ in
+                    self.preparePlayerViewController()
                     self.displayPlayerViewController()
                 }
             )

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -51,13 +51,12 @@ class SinglePlayerExampleController: UIViewController {
         "just-a-placeholder-now"
     }
     
+    // can also be a vercel deployment (once the pr is merged)
     var baseTestServerURL = "http://127.0.0.1:8789"
-//    var baseTestServerURL = "http://127.0.0.1:8789"
 
     var url: String {
-//        "\(baseTestServerURL)/single-mp-shortform/v1/av-muxed-media.m3u8"
-        "\(baseTestServerURL)/single-mp-shortform/v1/av-muxed-media-duration-in-init-seg.m3u8"
-//        "\(baseTestServerURL)/av-muxed-media-duration-in-init-seg.m3u8"
+        "\(baseTestServerURL)/short-form-tests/v1/id-duration-in-init-segment/media.m3u8"
+        //        "\(baseTestServerURL)/av-muxed-media-duration-in-init-seg.m3u8"
 //        "\(baseTestServerURL)/av-muxed-media.m3u8"
         //ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
     }

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -57,6 +57,7 @@ class SinglePlayerExampleController: UIViewController {
     var baseTestServerURL = "mux-short://127.0.0.1:8789"
 
     var url: String {
+//        "\(baseTestServerURL)/short-form-tests/v1/id-single-mp-spec-compliant/media.m3u8"
         "\(baseTestServerURL)/short-form-tests/v1/id-duration-in-init-segment/media.m3u8"
         //        "\(baseTestServerURL)/av-muxed-media-duration-in-init-seg.m3u8"
 //        "\(baseTestServerURL)/av-muxed-media.m3u8"

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -51,9 +51,14 @@ class SinglePlayerExampleController: UIViewController {
         "just-a-placeholder-now"
     }
     
+    var baseTestServerURL = "http://127.0.0.1:8789"
+//    var baseTestServerURL = "http://127.0.0.1:8789"
+
     var url: String {
-        "http://localhost:3000/av-muxed-media-duration-in-init-seg.m3u8"
-//        "http://localhost:3000/av-muxed-media.m3u8"
+//        "\(baseTestServerURL)/single-mp-shortform/v1/av-muxed-media.m3u8"
+        "\(baseTestServerURL)/single-mp-shortform/v1/av-muxed-media-duration-in-init-seg.m3u8"
+//        "\(baseTestServerURL)/av-muxed-media-duration-in-init-seg.m3u8"
+//        "\(baseTestServerURL)/av-muxed-media.m3u8"
         //ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
     }
 

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UIKit
 
 import MuxPlayerSwift
+import MuxCore
 
 // Single player example
 class SinglePlayerExampleController: UIViewController {
@@ -35,7 +36,8 @@ class SinglePlayerExampleController: UIViewController {
             )
         } else {
             MonitoringOptions(
-                playbackID: playbackID
+                //playbackID: "just-a-monitoring-placeholder"
+                customerData: MUXSDKCustomerData(), playerName: "shortform-demo-\(UUID().uuidString)"
             )
         }
     }
@@ -44,6 +46,11 @@ class SinglePlayerExampleController: UIViewController {
 
     var playbackID: String {
         ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
+    }
+    
+    var url: String {
+        "http://localhost:3000/av-muxed-media.m3u8"
+        //ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
     }
 
     var minimumResolutionTier: MinResolutionTier = .default {

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -51,8 +51,8 @@ class SinglePlayerExampleController: UIViewController {
         "just-a-placeholder-now"
     }
     
-    // can also be a vercel deployment (once the pr is merged)
-    var baseTestServerURL = "http://127.0.0.1:8789"
+//    var baseTestServerURL = "http://127.0.0.1:8789"
+    var baseTestServerURL = "mux-short://127.0.0.1:8789"
 
     var url: String {
         "\(baseTestServerURL)/short-form-tests/v1/id-duration-in-init-segment/media.m3u8"

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -45,7 +45,8 @@ class SinglePlayerExampleController: UIViewController {
     // MARK: Mux Video Playback Parameters
 
     var playbackID: String {
-        ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
+//        ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
+        "just-a-placeholder-now"
     }
     
     var url: String {
@@ -85,9 +86,8 @@ class SinglePlayerExampleController: UIViewController {
     }
 
     func preparePlayerViewController() {
-        playerViewController.prepare(
-            playbackID: playbackID,
-            playbackOptions: PlaybackOptions(
+        // TODO: not the real api i guess
+        let playbackOptions =  PlaybackOptions(
                 maximumResolutionTier: maximumResolutionTier,
                 minimumResolutionTier: minimumResolutionTier,
                 renditionOrder: renditionOrder,
@@ -95,7 +95,18 @@ class SinglePlayerExampleController: UIViewController {
                     assetStartTimeInSeconds: assetStartTimeInSeconds,
                     assetEndTimeInSeconds: assetEndTimeInSeconds
                 )
-            ),
+                )
+                
+        let playerItem = AVPlayerItem(
+            url: URL(string:"http://localhost:3000/av-muxed-media.m3u8")!,
+            playbackID: playbackID,
+            playbackOptions: playbackOptions
+        )
+
+        playerViewController.prepare(
+            playbackID: playbackID,
+            playerItem: playerItem, // TODO: not the real api etc
+            playbackOptions: playbackOptions,
             monitoringOptions: monitoringOptions
         )
     }

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -52,7 +52,8 @@ class SinglePlayerExampleController: UIViewController {
     }
     
     var url: String {
-        "http://localhost:3000/av-muxed-media.m3u8"
+        "http://localhost:3000/av-muxed-media-duration-in-init-seg.m3u8"
+//        "http://localhost:3000/av-muxed-media.m3u8"
         //ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
     }
 
@@ -100,7 +101,7 @@ class SinglePlayerExampleController: UIViewController {
                 )
                 
         let playerItem = AVPlayerItem(
-            url: URL(string:"http://localhost:3000/av-muxed-media.m3u8")!,
+            url: URL(string:url)!,
             playbackID: playbackID,
             playbackOptions: playbackOptions
         )

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -16,7 +16,7 @@ class SinglePlayerExampleController: UIViewController {
 
     // MARK: Player View Controller
 
-    // TODO: aw christ
+    // TODO: changed for PoC. For now we're just feeding URLs in directly, though our public APIs are intended to obfuscate that
     lazy var playerViewController = AVPlayerViewController()
 //    lazy var playerViewController = AVPlayerViewController(
 //        playbackID: playbackID
@@ -52,7 +52,6 @@ class SinglePlayerExampleController: UIViewController {
     }
     
     // TODO: To use the LoaderDelegate, we need a custom scheme. Here, I'm setting this up in the viewcontroller, but the best place to do this would be in the URLComponents extension, where we'd do this instead of swapping-in the reverse proxy URL.
-    // TODO: Given the above, we have two options that differ in a few ways (but mostly in devex). Explain what those ways are and socialize the choice between doing this
 //    var baseTestServerURL = "http://127.0.0.1:8789"
     var baseTestServerURL = "mux-short://127.0.0.1:8789"
 

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -51,6 +51,8 @@ class SinglePlayerExampleController: UIViewController {
         "just-a-placeholder-now"
     }
     
+    // TODO: To use the LoaderDelegate, we need a custom scheme. Here, I'm setting this up in the viewcontroller, but the best place to do this would be in the URLComponents extension, where we'd do this instead of swapping-in the reverse proxy URL.
+    // TODO: Given the above, we have two options that differ in a few ways (but mostly in devex). Explain what those ways are and socialize the choice between doing this
 //    var baseTestServerURL = "http://127.0.0.1:8789"
     var baseTestServerURL = "mux-short://127.0.0.1:8789"
 

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/SinglePlayerExampleController.swift
@@ -58,7 +58,7 @@ class SinglePlayerExampleController: UIViewController {
 
     var url: String {
 //        "\(baseTestServerURL)/short-form-tests/v1/id-single-mp-spec-compliant/media.m3u8"
-        "\(baseTestServerURL)/short-form-tests/v1/id-duration-in-init-segment/media.m3u8"
+        "\(baseTestServerURL)/short-form-tests/v1/id-duration-600s-in-init-segment/media.m3u8"
         //        "\(baseTestServerURL)/av-muxed-media-duration-in-init-seg.m3u8"
 //        "\(baseTestServerURL)/av-muxed-media.m3u8"
         //ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"

--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -34,6 +34,8 @@ class PlayerSDK {
     // TODO: Only works if we have a custom url scheme
     let resourceLoaderDelegate = ShortFormAssetLoaderDelegate()
     let resourceLoaderDispatchQueue = DispatchQueue(label: "shortform-resource-loader")
+    // just for a quick sanity test
+    let loggingDelegate = RequestLoggingAssetLoaderDelegate()
     
     // TODO: not the final form. The real player will need to support an arbitrary number of these tasks, presumably cleaning up the tasks as they finish or something
 //    var shortFormPlaylistTask: Task<Data, any Error>?

--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -100,7 +100,7 @@ class PlayerSDK {
         
         self.reverseProxyServer = ReverseProxyServer()
         
-        // TODO: Maybe there's some other way but I don't care
+        // TODO: should rely on DEBUG flag
         self.enableLogging()
     }
 

--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -29,6 +29,15 @@ class PlayerSDK {
 
     let fairPlaySessionManager: FairPlayStreamingSessionManager
 
+    // MARK: things for shortform PoC
+    
+    // TODO: Only works if we have a custom url scheme
+    let resourceLoaderDelegate = ShortFormAssetLoaderDelegate()
+    let resourceLoaderDispatchQueue = DispatchQueue(label: "shortform-resource-loader")
+    
+    // TODO: not the final form. The real player will need to support an arbitrary number of these tasks, presumably cleaning up the tasks as they finish or something
+//    var shortFormPlaylistTask: Task<Data, any Error>?
+    
     convenience init() {
         let monitor = Monitor()
 
@@ -92,7 +101,11 @@ class PlayerSDK {
                 category: "External"
             )
         )
+        
         self.reverseProxyServer = ReverseProxyServer()
+        
+        // TODO: Maybe there's some other way but I don't care
+        self.enableLogging()
     }
 
     func enableLogging() {

--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -31,11 +31,8 @@ class PlayerSDK {
 
     // MARK: things for shortform PoC
     
-    // TODO: Only works if we have a custom url scheme
     let resourceLoaderDelegate = ShortFormAssetLoaderDelegate()
     let resourceLoaderDispatchQueue = DispatchQueue(label: "shortform-resource-loader")
-    // just for a quick sanity test
-    let loggingDelegate = RequestLoggingAssetLoaderDelegate()
     
     // TODO: not the final form. The real player will need to support an arbitrary number of these tasks, presumably cleaning up the tasks as they finish or something
 //    var shortFormPlaylistTask: Task<Data, any Error>?

--- a/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/GlobalLifecycle/PlayerSDK.swift
@@ -34,9 +34,6 @@ class PlayerSDK {
     let resourceLoaderDelegate = ShortFormAssetLoaderDelegate()
     let resourceLoaderDispatchQueue = DispatchQueue(label: "shortform-resource-loader")
     
-    // TODO: not the final form. The real player will need to support an arbitrary number of these tasks, presumably cleaning up the tasks as they finish or something
-//    var shortFormPlaylistTask: Task<Data, any Error>?
-    
     convenience init() {
         let monitor = Monitor()
 

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -13,7 +13,8 @@ internal enum PlaybackURLConstants {
     static let reverseProxyPort = Int(1234)
 }
 
-internal extension AVPlayerItem {
+// TODO: not a public API. this extension has been modified. It has been hackily refactored to fit your proof-of-concept
+public extension AVPlayerItem {
 
     // Initializes a player item with a playback URL that
     // references your Mux Video at the supplied playback ID.
@@ -26,7 +27,15 @@ internal extension AVPlayerItem {
     // - Parameter playbackID: playback ID of the Mux Asset
     // you'd like to play
     convenience init(playbackID: String) {
+        guard let playbackURL = URLComponents(
+           playbackID: playbackID,
+           playbackOptions: PlaybackOptions()
+       ).url else {
+           preconditionFailure("Invalid playback URL components")
+       }
+        
         self.init(
+            playbackURL: playbackURL,
             playbackID: playbackID,
             playbackOptions: PlaybackOptions(),
             playerSDK: .shared
@@ -44,27 +53,31 @@ internal extension AVPlayerItem {
         playbackID: String,
         playbackOptions: PlaybackOptions
     ) {
-        self.init(
-            playbackID: playbackID,
-            playbackOptions: playbackOptions,
-            playerSDK: .shared
-        )
-    }
-
-    convenience init(
-        playbackID: String,
-        playbackOptions: PlaybackOptions,
-        playerSDK: PlayerSDK
-    ) {
-        // Create a new `AVAsset` that has been prepared
-        // for playback
-        guard let playbackURL = URLComponents(
+         guard let playbackURL = URLComponents(
             playbackID: playbackID,
             playbackOptions: playbackOptions
         ).url else {
             preconditionFailure("Invalid playback URL components")
         }
 
+        self.init(
+            playbackURL: playbackURL,
+            playbackID: playbackID,
+            playbackOptions: playbackOptions,
+            playerSDK: .shared
+        )
+    }
+    
+    
+    internal convenience init(
+        playbackURL: URL,
+        playbackID: String,
+        playbackOptions: PlaybackOptions,
+        playerSDK: PlayerSDK
+    ) {
+        // Create a new `AVAsset` that has been prepared
+        // for playback
+       
         let asset = AVURLAsset(
             url: playbackURL
         )
@@ -81,7 +94,7 @@ internal extension AVPlayerItem {
     }
 }
 
-internal extension AVPlayerItem {
+public extension AVPlayerItem {
 
     // Extracts Mux playback ID from remote AVAsset, if possible
     var playbackID: String? {

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -189,6 +189,8 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
                 
                 let playlistData = Data() // TODO
                 loadingRequest.dataRequest!.respond(with: playlistData)
+                // TODO: handle Errors by actually catching something :)
+                loadingRequest.finishLoading()
             }
 
             return true
@@ -308,10 +310,11 @@ internal class ShortFormMediaPlaylistGenerator {
             Tags.version(7),
             Tags.mediaSequence(startingFromSequenceNumber: 0),
             // TODO: Construct absolute URI? I think so, because we need to point to the reverse proxy
-            Tags.map(uri: "init.mp4", range: nil)
+            Tags.map(uri: "init.mp4", range: nil),
+            Tags.discontunityMarker()
         ]
         
-        return ""
+        return lines.joined(separator: "\n")
     }
     
     /// @param originBaseURL: An aboslute URL that points to the path where segments can be found (ie, `https://shortform.mux.com/abc23/`
@@ -332,9 +335,9 @@ internal class ShortFormMediaPlaylistGenerator {
     
     struct PlaylistAttributes {
         let version: UInt
-        // TODO: Mux Video's target duration is 5sec, but the test assets have a duration of 4(ish), possibly because they were created from an fmp4 with a ~4.1sec keyframe interval (and accompanying sidx)
+        // TODO: Mux Video's target duration is 5sec, but the test assets have a duration of 4(ish), possibly because they were created from an source with a ~4.1sec keyframe interval (and/or accompanying sidx)
         let targetDuration: UInt
-        let extinfSegmentDuration: Float? // assumed to be the target duration if not specified
+        let extinfSegmentDuration: Double? // assumed to be the target duration if not specified
     }
     
     private class Tags {

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -104,7 +104,10 @@ public extension AVPlayerItem {
         self.init(
             asset: asset
         )
-
+        
+        // Added for the proof-of-concept. The default is a lot more than this, like half the video. If we want shortform to be cheap for customers, we don't want to prewarm 300sec of video
+        self.preferredForwardBufferDuration = 10.0
+        
         playerSDK.registerPlayerItem(
             self,
             playbackID: playbackID,

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -296,10 +296,9 @@ internal class ShortFormMediaPlaylistGenerator {
     static let movieHeaderType: Data = "mvhd".data(using: .ascii)!
     
     let initSegmentData: Data
-    let basePath: String
-    let host: String
     let playlistAttributes: PlaylistAttributes
-    let scheme: String
+    let originBase: URLComponents
+    let cacheProxyBase: URLComponents
     
     func playlistString() -> String {
         // Reminder: If we are generating playlists from inside the loader delegate, we need to point at the Reverse Proxy from here, for each segment (including the init segment, which we don't want to fetch again)
@@ -315,25 +314,27 @@ internal class ShortFormMediaPlaylistGenerator {
         return ""
     }
     
+    /// @param originBaseURL: An aboslute URL that points to the path where segments can be found (ie, `https://shortform.mux.com/abc23/`
+    /// @param cacheProxyURL: An absolute URL that points to the path where the cache proxy is (ie, `http://127.0.0.1:1234/`)
     init(
         initSegment: Data,
-        host: String,
-        scheme: String,
-        basePath: String,
+        originBaseURL: URL,
+        cacheProxyURL: URL,
         playlistAttributes: PlaylistAttributes
     ) {
         self.initSegmentData = initSegment
-        self.basePath = basePath
-        self.host = host
-        self.scheme = scheme
         self.playlistAttributes = playlistAttributes
+        
+        // since we are not resolvingAgainstBaseURL, there's no risk of these initializers returning nil
+        self.cacheProxyBase = URLComponents(url: cacheProxyURL, resolvingAgainstBaseURL: false)!
+        self.originBase = URLComponents(url: originBaseURL, resolvingAgainstBaseURL: false)!
     }
     
     struct PlaylistAttributes {
         let version: UInt
         // TODO: Mux Video's target duration is 5sec, but the test assets have a duration of 4(ish), possibly because they were created from an fmp4 with a ~4.1sec keyframe interval (and accompanying sidx)
         let targetDuration: UInt
-        let extinfSegmentDuration: Float? // inferred from targetDuration if not specified
+        let extinfSegmentDuration: Float? // assumed to be the target duration if not specified
     }
     
     private class Tags {

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -302,8 +302,14 @@ internal class ShortFormMediaPlaylistGenerator {
     let scheme: String
     
     func playlistString() -> String {
+        // Reminder: If we are generating playlists from inside the loader delegate, we need to point at the Reverse Proxy from here, for each segment (including the init segment, which we don't want to fetch again)
+        
         let lines = [
-            Tags.extM3U()
+            Tags.extM3U(),
+            Tags.version(7),
+            Tags.mediaSequence(startingFromSequenceNumber: 0),
+            // TODO: Construct absolute URI? I think so, because we need to point to the reverse proxy
+            Tags.map(uri: "init.mp4", range: nil)
         ]
         
         return ""

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -270,8 +270,11 @@ internal enum ShortFormRequestError: Error {
     case unexpected(url: URL?, message: String)
 }
 
-/// Fetches the resource at the URL specified by the given URLRequest. This class can only be used once. To make more requests, make more
-/// AsyncFetchers.
+/// Fetches the resource at the URL specified by the given URLRequest. Handles the state of the underlying URLSesisonTask,
+/// canceling it if the parent task that started the fetch is ever canceled.
+///
+/// This class can only be used once. To make more requests, make more AsyncFetchers.
+///
 /// Start fetching with ``fetch`` and cancel either by canceling your parent Task or out-of-band using ``cancel``
 internal actor AsyncFetcher {
     // TODO: Can also use this for the other segments when we replace GCDWebServer but we gotta add a callback to deliver the Data in segments as it arrives.. No need to check cancellation while handling those buffers, since our cancel() method also cancels the task
@@ -299,6 +302,7 @@ internal actor AsyncFetcher {
         }
     }
     
+    /// Cancels the inner fetch task and url session task if required.
     func cancel() {
         // also called internally to handle the parent task of doFetch getting cancelled
         fetchTask?.cancel()

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -442,9 +442,7 @@ internal class ShortFormMediaPlaylistGenerator {
             Tags.version(7),
             Tags.targetDuration(playlistAttributes.targetDuration),
             Tags.mediaSequence(startingFromSequenceNumber: 0),
-            // TODO: Construct absolute URI? I think so, because we need to point to the reverse proxy
             Tags.map(uri: "\(originBaseURLStr)/init.mp4", range: nil),
-//            Tags.map(uri: "init.mp4", range: nil),
             Tags.discontunityMarker()
         ]
         
@@ -459,7 +457,6 @@ internal class ShortFormMediaPlaylistGenerator {
         
         var segmentLines: [String] = []
         for segmentNumber in 0..<Int(wholeSegments) {
-//            let segmentBasename = "\(segmentNumber).mp4"
             let segmentBasename = "\(originBaseURLStr)/\(segmentNumber).mp4"
             segmentLines.append(Tags.extinf(segmentDuration: segmentDuration, title: nil))
             segmentLines.append(segmentBasename)
@@ -468,23 +465,11 @@ internal class ShortFormMediaPlaylistGenerator {
         segmentLines.append(Tags.extinf(segmentDuration: lastSegmentDuration, title: nil))
         segmentLines.append("\(originBaseURLStr)/\(Int(numberOfSegments - 1)).mp4")
         
-        // TODO: ffmpeg always geneates one more segment with a really small duration. What is with that
+        // TODO: ffmpeg generates one really short segment at the end. I think it has the last audio sample in it (since the 'fake mez' we generated test assets from has slightly longer audio than video)
         // i promise "postamble" is a real word
         let postambleLines = [
             Tags.endlist()
         ]
-        
-        let numSegUlp = segmentsPerStream.ulp
-        let numSegNextUp = segmentsPerStream.nextUp
-        let numSegNextDown = segmentsPerStream.nextDown
-//        let segmentDurationByTargetOnly = Double(playlistAttributes.targetDuration)
-//        let numberOfSegmentsByTargetOnly = mvhdDuration / segmentDurationByTargetOnly
-
-        // What do we want here? The int-part of the number of segments, plus another segment with whatever is left (some fraction of a segment)
-        
-        // TODO: Last segment
-        
-        // Ok, now we need to 1) Extract the duration from the init segment data 2) use the power of division to get the duration in segments and 3) generate EXTINF/segment-urls for each and 4) Point to the caching proxy (for the proof-of-concept, can do this in all cases)
         
         return (preambleLines + segmentLines + postambleLines).joined(separator: "\n")
     }
@@ -541,7 +526,6 @@ internal class ShortFormMediaPlaylistGenerator {
     
     struct PlaylistAttributes {
         let version: UInt
-        // TODO: Mux Video's target duration is 5sec, but the test assets have a duration of 4(ish), possibly because they were created from an source with a ~4.1sec keyframe interval (and/or accompanying sidx)
         let targetDuration: UInt
         let extinfSegmentDuration: Double? // assumed to be the target duration if not specified
     }
@@ -562,7 +546,6 @@ internal class ShortFormMediaPlaylistGenerator {
         static func mediaSequence(startingFromSequenceNumber sn: UInt) -> String {
             return "#EXT-X-MEDIA-SEQUENCE:\(sn)"
         }
-//        func map(uri: String, startingByte start: UInt?, offsetFromStart offset: UInt?) -> String {
         static func map(uri: String, range: (UInt, UInt?)?) -> String {
             let base = "#EXT-X-MAP:URI=\"\(uri)\""
             if let (start, offset) = range {

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -155,7 +155,12 @@ public extension AVPlayerItem {
 internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDelegate {
     // TODO: The final impl of this may depend on a source of duration other than spec-deviant init segments
     static let movieHeaderType: Data = "mvhd".data(using: .ascii)! // not risky
+    // relative to the start of the box
+    static let movieHeaderTimeScaleOffset: Int = 20
+    // relative to the start of the box
+    static let movieHeaderDurationOffset: Int = 24
     
+
     // TODO: In the real thing, we'll need to support multiple Tasks at the same time since you can have multiple items. Accomplish this either by having multiple delegates (hard because we don't really have an object with a predictable lifecycle that can own them except indefinitely) or by having multiple Tasks and init segments cached someplace (might still be hard because we still don't have anything with a known lifecycle that we control that can own *those*)
     private var fetchTask: Task<Void, any Error>? = nil
     
@@ -330,8 +335,8 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
             throw ShortFormRequestError.unexpected(message: "mvhd end was out of bounds")
         }
         
-        let timescaleStart = boxStart + ShortFormMediaPlaylistGenerator.movieHeaderTimeScaleOffset
-        let durationStart = boxStart + ShortFormMediaPlaylistGenerator.movieHeaderDurationOffset
+        let timescaleStart = boxStart + Self.movieHeaderTimeScaleOffset
+        let durationStart = boxStart + Self.movieHeaderDurationOffset
         let timescale = try readInt32(data: mp4Data, at: UInt(timescaleStart))
         let duration = try readInt32(data: mp4Data, at: UInt(durationStart))
         
@@ -350,11 +355,6 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
 }
 
 internal class ShortFormMediaPlaylistGenerator {
-    // relative to the start of the box
-    static let movieHeaderTimeScaleOffset: Int = 20
-    // relative to the start of the box
-    static let movieHeaderDurationOffset: Int = 24
-    
     let assetDuration: TimeInterval
     let playlistAttributes: PlaylistAttributes
     let originBase: URLComponents

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -378,11 +378,11 @@ internal class ShortFormMediaPlaylistGenerator {
         ]
         
         // TODO: Might want to check the trak's too, and take the longest duration(?)
-        let mvhdDuration = self.assetDuration
+        let duration = self.assetDuration
         
         let segmentDuration = playlistAttributes.extinfSegmentDuration
             ?? Double(playlistAttributes.targetDuration)
-        let segmentsPerStream = mvhdDuration / segmentDuration
+        let segmentsPerStream = duration / segmentDuration
         let numberOfSegments = ceil(segmentsPerStream) // including the last segment
         let wholeSegments = floor(segmentsPerStream)
         let lastSegmentDuration = (numberOfSegments - wholeSegments) * segmentDuration

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -173,7 +173,7 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
                 await MainActor.run { PlayerSDK.shared.reverseProxyServer.start() }
                 
                 do {
-                    try await answerRequestForPlaylist(
+                    try await answerRequestForMediaPlaylist(
                         resourceLoadingRequest: loadingRequest,
                         playlistURL: url,
                         originBaseURL: makeOriginBaseURL(playlistURL: url),
@@ -202,7 +202,7 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
         fetchTask?.cancel()
     }
     
-    private func answerRequestForPlaylist(
+    private func answerRequestForMediaPlaylist(
         resourceLoadingRequest loadingRequest: AVAssetResourceLoadingRequest,
         playlistURL: URL,
         originBaseURL: URL,
@@ -219,6 +219,8 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
         let segmentData = try await fetchInitSegment(initSegmentURL: initSegmentURL)
         PlayerSDK.shared.diagnosticsLogger.debug("resourceLoader fetched \(segmentData.count) bytes")
         
+        // TODO: The target duration (and real segment duration; can be different) should maybe come down from the server via Response Header, if that's the way the origin is going to give us information
+        // TODO: (continued) .. although for playback, we might not need the real target duration...
         let playlistString = try ShortFormMediaPlaylistGenerator(
             initSegment: segmentData,
             originBaseURL: originBaseURL,

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -13,7 +13,7 @@ internal enum PlaybackURLConstants {
     static let reverseProxyPort = Int(1234)
 }
 
-// TODO: not a public API. this extension has been modified. It has been hackily refactored to fit your proof-of-concept
+// TODO: not a public API. this extension has been modified. It has been hackily refactored to fit our proof-of-concept
 public extension AVPlayerItem {
 
     // Initializes a player item with a playback URL that

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -249,8 +249,6 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
         loadingRequest.contentInformationRequest?.contentLength = Int64(playlistData.count)
         loadingRequest.contentInformationRequest?.isByteRangeAccessSupported = true
         
-        // TODO: Also need to cache the init segment
-        
         loadingRequest.dataRequest!.respond(with: playlistData)
         loadingRequest.finishLoading()
     }

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -174,7 +174,7 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
                         resourceLoadingRequest: loadingRequest,
                         playlistURL: url,
                         originBaseURL: makeOriginBaseURL(playlistURL: url),
-                        proxyCacheBaseURL: URL(string: "https://mux.com")! // TODO: Real URL
+                        cacheBaseURL: URL(string: "https://mux.com")! // TODO: Real URL
                     )
                 } catch {
                     PlayerSDK.shared.diagnosticsLogger.error(
@@ -203,7 +203,7 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
         resourceLoadingRequest loadingRequest: AVAssetResourceLoadingRequest,
         playlistURL: URL,
         originBaseURL: URL,
-        proxyCacheBaseURL: URL
+        cacheBaseURL: URL
     ) async throws {
         let initSegmentURL = makeInitSegmentURL(playlistURL: playlistURL)
         PlayerSDK.shared.diagnosticsLogger.info(
@@ -216,7 +216,7 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
         let playlistString = try ShortFormMediaPlaylistGenerator(
             initSegment: segmentData,
             originBaseURL: originBaseURL,
-            cacheProxyBaseURL: URL(string: "https://mux.com")!, // TODO: Real URL
+            cacheProxyBaseURL: cacheBaseURL,
             playlistAttributes: ShortFormMediaPlaylistGenerator.PlaylistAttributes(
                 version: 7,
 //                        targetDuration: 5, // TODO: wouldn't a mux video asset have 6?
@@ -267,6 +267,22 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
     
     private func makeInitSegmentURL(playlistURL: URL) -> URL {
         return URL(string:"\(makeOriginBaseURL(playlistURL: playlistURL))/init.mp4")!
+    }
+    
+    private func makeCacheProxyURL(forFullURL url: URL) -> URL {
+        var components = URLComponents()
+        components.scheme = PlaybackURLConstants.reverseProxyScheme
+        components.host = PlaybackURLConstants.reverseProxyHost
+        components.port = PlaybackURLConstants.reverseProxyPort
+        
+        components.queryItems = [
+            URLQueryItem(
+                name: PlayerSDK.shared.reverseProxyServer.originURLKey,
+                value: url.absoluteString
+            )
+        ]
+        
+        return components.url!
     }
     
     private func makeOriginBaseURL(playlistURL: URL) -> URL {

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -195,7 +195,8 @@ internal class ShortFormAssetLoaderDelegate : NSObject, AVAssetResourceLoaderDel
         _ resourceLoader: AVAssetResourceLoader,
         didCancel loadingRequest: AVAssetResourceLoadingRequest
     ) {
-        
+        // As long as the methods of this delegate are called without interleaving (i think they are), this should be fine
+        fetchTask?.cancel()
     }
     
     private func answerRequestForPlaylist(

--- a/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/AVPlayerItem+Mux.swift
@@ -68,6 +68,19 @@ public extension AVPlayerItem {
         )
     }
     
+    //TODO: something to make sure the item is prepared? only if this becomes the real api
+    convenience init(
+        url: URL,
+        playbackID: String,
+        playbackOptions: PlaybackOptions
+    ) {
+        self.init(
+            playbackURL: url,
+            playbackID: playbackID,
+            playbackOptions: playbackOptions,
+            playerSDK: .shared
+        )
+    }
     
     internal convenience init(
         playbackURL: URL,

--- a/Sources/MuxPlayerSwift/InternalExtensions/URLComponents+Mux.swift
+++ b/Sources/MuxPlayerSwift/InternalExtensions/URLComponents+Mux.swift
@@ -5,7 +5,12 @@
 import Foundation
 
 internal extension URLComponents {
-
+    
+    // TODO: Just for the proof-of-concept.
+    // may need to set this to something else for your own test
+    static let shortFormTestServerHost = "http://127.0.0.1:8789"
+    static let shortFormTestAssetVersion = "v1"
+    
     // MARK: - Playback URL Construction
 
     init(
@@ -15,9 +20,11 @@ internal extension URLComponents {
         self.init()
         self.scheme = "https"
 
-        self.host = "stream.\(playbackOptions.rootDomain())"
-        self.path = "/\(playbackID).m3u8"
-
+//        self.host = "stream.\(playbackOptions.rootDomain())"
+//        self.path = "/\(playbackID).m3u8"
+        self.host = URLComponents.shortFormTestServerHost
+        self.path = "/\(URLComponents.shortFormTestAssetVersion)/\(playbackID).m3u8"
+        
         if case PlaybackOptions.PlaybackPolicy.public(
             let publicPlaybackOptions
         ) = playbackOptions.playbackPolicy {
@@ -118,7 +125,8 @@ internal extension URLComponents {
 
         }
 
-        let isReverseProxyEnabled = playbackOptions.enableSmartCache
+        let isReverseProxyEnabled = true//playbackOptions.enableSmartCache
+//        let isReverseProxyEnabled = playbackOptions.enableSmartCache
 
         if isReverseProxyEnabled {
             // TODO: clean up

--- a/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerViewController+Mux.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerViewController+Mux.swift
@@ -270,6 +270,25 @@ extension AVPlayerViewController {
             monitoringOptions: monitoringOptions
         )
     }
+    
+    public func prepare(
+        playbackID: String,
+        // TODO: I mean, ppl should be able to provide AVPlayerItems but optionally. I just needed to quickly provide a deocrated player item
+        playerItem: AVPlayerItem,
+        playbackOptions: PlaybackOptions,
+        monitoringOptions: MonitoringOptions
+    ) {
+        prepare(
+//            playerItem: AVPlayerItem(
+//                playbackID: playbackID,
+//                playbackOptions: playbackOptions
+//            ),
+            playerItem: playerItem,
+            playbackID: playbackID,
+            playbackOptions: playbackOptions,
+            monitoringOptions: monitoringOptions
+        )
+    }
 
     internal func prepare(
         playerItem: AVPlayerItem,

--- a/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerViewController+Mux.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Extensions/AVPlayerViewController+Mux.swift
@@ -273,7 +273,7 @@ extension AVPlayerViewController {
     
     public func prepare(
         playbackID: String,
-        // TODO: I mean, ppl should be able to provide AVPlayerItems but optionally. I just needed to quickly provide a deocrated player item
+        // TODO: This is not intended to be the final API. It's just for the PoC so I can specify a good URL
         playerItem: AVPlayerItem,
         playbackOptions: PlaybackOptions,
         monitoringOptions: MonitoringOptions

--- a/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
+++ b/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
@@ -276,6 +276,10 @@ class ReverseProxyServer {
         ) { [weak self] request, completion in
             
             PlayerSDK.shared.diagnosticsLogger.debug("Got segment Request to \(request.url.absoluteString)")
+            if request.url.lastPathComponent == "init.mp4" {
+                
+                PlayerSDK.shared.diagnosticsLogger.debug("!!! INIT SEGMENT REQUESTED")
+            }
             
             guard let self = self else {
                 return completion(

--- a/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
+++ b/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
@@ -271,7 +271,7 @@ class ReverseProxyServer {
     private func setupCMAFSegmentHandler() {
         self.webServer.addHandler(
             forMethod: "GET",
-            pathRegex: "^/.*\\.m4s$",
+            pathRegex: "^/.*\\.(m4s|mp4)$", // TODO: For the shortform proposal: test assets crrently have mp4
             request: GCDWebServerRequest.self
         ) { [weak self] request, completion in
 

--- a/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
+++ b/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
@@ -100,6 +100,9 @@ class ReverseProxyServer {
             )
 
             if originURL.pathExtension == "m3u8" {
+                
+                // TODO: If we don't want to use a custom scheme then this is the place where we'd go
+                
                 let task = session.dataTask(
                     with: originURL
                 ) { data, response, error in

--- a/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
+++ b/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
@@ -101,7 +101,7 @@ class ReverseProxyServer {
 
             if originURL.pathExtension == "m3u8" {
                 
-                // TODO: If we don't want to use a custom scheme then this is the place where we'd go
+                // TODO: If we don't want to use a custom scheme then this is the place where we'd start fetching the init segment
                 
                 let task = session.dataTask(
                     with: originURL
@@ -277,8 +277,7 @@ class ReverseProxyServer {
             
             PlayerSDK.shared.diagnosticsLogger.debug("Got segment Request to \(request.url.absoluteString)")
             if request.url.lastPathComponent == "init.mp4" {
-                
-                PlayerSDK.shared.diagnosticsLogger.debug("!!! INIT SEGMENT REQUESTED")
+                PlayerSDK.shared.diagnosticsLogger.debug("init segment requested")
             }
             
             guard let self = self else {

--- a/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
+++ b/Sources/MuxPlayerSwift/ReverseProxyServer/ReverseProxyServer.swift
@@ -274,7 +274,9 @@ class ReverseProxyServer {
             pathRegex: "^/.*\\.(m4s|mp4)$", // TODO: For the shortform proposal: test assets crrently have mp4
             request: GCDWebServerRequest.self
         ) { [weak self] request, completion in
-
+            
+            PlayerSDK.shared.diagnosticsLogger.debug("Got segment Request to \(request.url.absoluteString)")
+            
             guard let self = self else {
                 return completion(
                     GCDWebServerDataResponse(


### PR DESCRIPTION
This plays short-form HLS streams whose playlists and segments match a particular format, by generating a media playlist based on a specially-prepared init segment

This PR doesn't assume anything in particular about the public APIs for constructing `AVPlayerItem`s configured for this approach. I had to change the public APIs to support this project, but the production version of this feature will probably have abstract constructing playback URLS, the same as with our existing players on all platforms

## Alternate approaches

The delivery and processing piece of this is still being designed. The final implementation may vary from what is shown here, but not significantly enough to disprove this concept. Additional details are still developing. We may want to discuss them internally

## Remaining PoC work: Consuming response data as it arrives

The current architecture of our player prevents us from streaming segment data into the player as it arrives. We use `URLCache` and `GCDWebServer` in conjunction, both of which make it difficult to write the segments out until the requests for them are completed

We can and should fix this. The work is captured in [this ticket](https://github.com/orgs/muxinc/projects/70/views/1?pane=issue&itemId=102565305&issue=muxinc%7Cpsdks_and_dev_rel_team%7C279)