### PR TITLE
Allow callers to disable automatic error tracking with Mux Data

### DIFF
--- a/Sources/MuxPlayerSwift/Monitoring/Monitor.swift
+++ b/Sources/MuxPlayerSwift/Monitoring/Monitor.swift
@@ -166,7 +166,8 @@ class Monitor: ErrorDispatcher {
             }
         }
 
-        let shouldTrackErrorsAutomatically = !usingDRM
+        // If using DRM, MuxPlayerSwift tracks errors in order to enrich appcert/CKC request errors
+        let shouldTrackErrorsAutomatically = !usingDRM && options.automaticErrorTracking
 
         let binding = playerObservationContext.monitorAVPlayerViewController(
             playerViewController,
@@ -201,7 +202,7 @@ class Monitor: ErrorDispatcher {
                 player
             )
 
-            if usingDRM {
+            if usingDRM && options.automaticErrorTracking {
                 keyValueObservation.register(
                     player,
                     for: \.error,
@@ -327,7 +328,7 @@ class Monitor: ErrorDispatcher {
             }
         }
 
-        let shouldTrackErrorsAutomatically = !usingDRM
+        let shouldTrackErrorsAutomatically = !usingDRM && options.automaticErrorTracking
 
         let binding = playerObservationContext.monitorAVPlayerLayer(
             playerLayer,
@@ -362,7 +363,7 @@ class Monitor: ErrorDispatcher {
                 player
             )
 
-            if usingDRM {
+            if usingDRM && options.automaticErrorTracking {
                 keyValueObservation.register(
                     player,
                     for: \.error,

--- a/Sources/MuxPlayerSwift/PublicAPI/Options/MonitoringOptions.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Options/MonitoringOptions.swift
@@ -16,14 +16,20 @@ public struct MonitoringOptions {
     /// monitoring with Mux Data
     public var playerName: String
 
+    /// Track player errors automatically using Mux Data.
+    /// If you disable automatic error tracking, you can track errors using methods on ``MUXSDKStats``
+    public var automaticErrorTracking: Bool
+    
     var customerData: MUXSDKCustomerData?
 
     /// Initializes options to customize monitoring by Mux
     /// - Parameter playbackID: helps identify your Data environment,
-    public init(playbackID: String) {
+    /// - Parameter automaticErrorTracking: Track errors automatically in Mux Data. Default is true
+    public init(playbackID: String, automaticErrorTracking: Bool = true) {
         self.environmentKey = nil
         let uniquePlayerName = "\(playbackID)-\(UUID().uuidString)"
         self.playerName = uniquePlayerName
+        self.automaticErrorTracking = automaticErrorTracking
     }
 
     /// Initializes options to customize monitoring by Mux
@@ -31,9 +37,11 @@ public struct MonitoringOptions {
     ///   - environmentKey: identifies your Data environment,
     ///   generated in the Dashboard
     ///   - playerName: identifier of the player
-    public init(environmentKey: String, playerName: String) {
+    ///   - automaticErrorTracking: Track errors in automatically in Mux Data. Default is true
+    public init(environmentKey: String, playerName: String, automaticErrorTracking: Bool = true) {
         self.environmentKey = environmentKey
         self.playerName = playerName
+        self.automaticErrorTracking = automaticErrorTracking
     }
 
     /// Initializes options to customize monitoring by Mux
@@ -42,12 +50,15 @@ public struct MonitoringOptions {
     ///   - customerData: passed through as-is when initializing
     ///   Mux Data monitoring
     ///   - playerName: identifier of the player
+    ///   - automaticErrorTracking: Track errors automatically in Mux Data. Default is true
     public init(
         customerData: MUXSDKCustomerData,
-        playerName: String
+        playerName: String,
+        automaticErrorTracking: Bool = true
     ) {
         self.customerData = customerData
         self.environmentKey = nil
         self.playerName = playerName
+        self.automaticErrorTracking = automaticErrorTracking
     }
 }


### PR DESCRIPTION
This accommodates customers who have their own error reporting or recovery logic, by letting them report errors themselves