### PR TITLE
fix: startDownloadedAsset should never clobber existing data

### DIFF
--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -56,6 +56,38 @@ actor DownloadIndex {
     func all() -> [StoredAsset] {
         Array(assets.values)
     }
+    
+    func deleteDownloadedFiles(playbackID: String, removeFromIndex: Bool) async {
+        // Attempt to delete the local media file and CKC sidecar if present (if not present, it's fine)
+        if let stored = get(playbackID: playbackID) {
+            let fm = FileManager.default
+            // Delete media file
+            if let mediaPath = stored.localPath {
+                let mediaURL = URL(fileURLWithPath: mediaPath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
+                do {
+                    try fm.removeItem(at: mediaURL)
+                } catch {
+                    // not generally an error condition. file can be gone due to early cancellation or re-entrant calls to this method
+                    logger.trace("[Mux-Offline] Failed to delete media file at \(mediaURL.path): \(error)")
+                }
+            }
+            
+            // Delete CKC sidecar if any
+            if let ckcFilePath = stored.ckcFilePath {
+                let ckcFile = URL(fileURLWithPath: ckcFilePath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
+                do {
+                    try fm.removeItem(at: ckcFile)
+                } catch {
+                    // not generally an error condition. file can be gone due to early cancellation or re-entrant calls to this method
+                    logger.trace("[Mux-Offline] Failed to key id file at \(ckcFile.path): \(error)")
+                }
+            }
+        }
+        
+        if removeFromIndex {
+            delete(playbackID: playbackID)
+        }
+    }
 
     // MARK: - Partial Updates
 

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -80,10 +80,13 @@ actor DownloadManager {
         avAsset: AVURLAsset,
         options: DownloadOptions
     ) async -> AnyPublisher<DownloadEvent, Error> {
-        // TODO: Check if we have a saved asset already (by using findDownloadedAsset, for its checks)
-        //  I worry about findDownloadedAset racing with removeAsset, since both yeild for index.get() before doing conflicting stuff...
-        //  as part of this todo: deleteDownloadedFiles should probably go into the DownloadIndex, so it can
-        //  isolate the entire deletion process.. Otherwise maybe we get a stale index entry from findDownloadedAsset
+        // If we already have a completed asset, return it. Caller can use it, or if it's not playable, they can explicitly delete
+        let alreadyCompletedAsset = await findDownloadedAsset(playbackID: playbackID)
+        if let alreadyCompletedAsset {
+            return Just(.completed(alreadyCompletedAsset))
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
         
         // Download Task in-progress. Return events from it instead of starting a new task
         guard downloadTasksByPlaybackID[playbackID] == nil else {
@@ -99,7 +102,7 @@ actor DownloadManager {
         downloadTasksByPlaybackID[playbackID] = task
         
         // clean up any old files that might exist (due to failed tasks, etc) before starting
-        await deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: true)
+        await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: true)
         // store DownloadOptions, etc in the index before we start
         await index.upsert(StoredAsset.forNewDownload(playbackID: playbackID, options: options))
 
@@ -118,7 +121,7 @@ actor DownloadManager {
             // will also clear the subject, to avoid saving stale state
             sendError(URLError(.cancelled), for: playbackID)
         }
-        await deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: true)
+        await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: true)
     }
     
     func allCompletedAssets() async -> [DownloadedAsset] {
@@ -191,37 +194,6 @@ actor DownloadManager {
         return await downloadSession.allTasks
     }
 
-    private func deleteDownloadedFiles(playbackID: String, removeFromIndex: Bool) async {
-        // Attempt to delete the local media file and CKC sidecar if present (if not present, it's fine)
-        if let stored = await index.get(playbackID: playbackID) {
-            let fm = FileManager.default
-            // Delete media file
-            if let mediaPath = stored.localPath {
-                let mediaURL = URL(fileURLWithPath: mediaPath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
-                do {
-                    try fm.removeItem(at: mediaURL)
-                } catch {
-                    // not generally an error condition. file can be gone due to early cancellation or re-entrant calls to this method
-                    logger.trace("[Mux-Offline] Failed to delete media file at \(mediaURL.path): \(error)")
-                }
-            }
-            
-            // Delete CKC sidecar if any
-            if let ckcFilePath = stored.ckcFilePath {
-                let ckcFile = URL(fileURLWithPath: ckcFilePath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
-                do {
-                    try fm.removeItem(at: ckcFile)
-                } catch {
-                    // not generally an error condition. file can be gone due to early cancellation or re-entrant calls to this method
-                    logger.trace("[Mux-Offline] Failed to key id file at \(ckcFile.path): \(error)")
-                }
-            }
-        }
-        
-        if removeFromIndex {
-            await index.delete(playbackID: playbackID)
-        }
-    }
     
     private func subject(for playbackID: String) -> CurrentValueSubject<DownloadEvent, Error> {
         if let existingSubject = subjectsByPlaybackID[playbackID] { return existingSubject }
@@ -310,7 +282,8 @@ actor DownloadManager {
         }
 
         await index.updateIsComplete(playbackID: playbackID, isComplete: true, completeWithError: true)
-        await deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: false)
+        // Once a task errors, we can't resume where we left off, so just delete any partially-downloaded data
+        await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: false)
         
         // do these after the awaits, so callers that call startDownload to handle errors actually start one
         sendError(error, for: playbackID)


### PR DESCRIPTION
This is to match the documented, intended functionality. If there's a record of a download, it must be explicitly removed. We never remove any valid data automatically.

If you call `startDownload.*` for an asset you already downloaded, whether successful or failed, you'll get that record instead. This is to avoid orphaning large media files on the disk with no way to delete them

The concern I had around racing with deleteDownloadedFiles is resolved by moving it into the index. This way, the `index.get`/`index.delete` pair are properly treated as a critical section and we won't orphan any files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download start/error behavior and file-deletion ownership, which can impact persistence and cleanup of large offline media files if edge cases are missed.
> 
> **Overview**
> `startDownloadWithPublisher` now returns an already-downloaded completed asset instead of deleting/recreating data when the same `playbackID` is requested again.
> 
> File cleanup for a `playbackID` has been centralized into `DownloadIndex.deleteDownloadedFiles(...)` and `DownloadManager` now delegates removals and error cleanups to the index, reducing re-entrancy/race risk and avoiding orphaned media/CKC sidecar files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bea33575d287a11bee0dad9298367f2fc95c6a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->