### PR TITLE
NAT-407: Fix MuxPlayerContainerViewController crash on programmatic init

### DIFF
--- a/Sources/MuxPlayerSwift/PublicAPI/ViewController/MuxPlayerContainerViewController.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/ViewController/MuxPlayerContainerViewController.swift
@@ -56,7 +56,7 @@ public class MuxPlayerContainerViewController : UIViewController {
     
     public init(muxMetadata: MUXSDKCustomerData) {
         self.playerViewController = AVPlayerViewController()
-        super.init()
+        super.init(nibName: nil, bundle: nil)
         
         updateMuxMetadata(muxMetadata)
     }


### PR DESCRIPTION
[NAT-407]

## Summary
- `MuxPlayerContainerViewController.init(muxMetadata:)` called `super.init()` which routes to `init(nibName:bundle:)` — an initializer that was never overridden, causing a fatal crash
- Replace with `super.init(nibName: nil, bundle: nil)`, the standard UIViewController programmatic init pattern
- Only affects programmatic instantiation; storyboard-based usage via `init?(coder:)` is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line initializer fix confined to `MuxPlayerContainerViewController` that changes only the programmatic init path.
> 
> **Overview**
> Fixes a crash when creating `MuxPlayerContainerViewController(muxMetadata:)` programmatically by switching from `super.init()` to the standard `UIViewController` initializer `super.init(nibName: nil, bundle: nil)`.
> 
> Storyboard/nib initialization via `init?(coder:)` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3ed5c94a00102f187b52763e61bf935fe6311b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->