### PR TITLE
Add DRM Offline Access

### DIFF
--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		359DA8042EE8F8E400491BCE /* ContainerViewControllerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359DA8032EE8F8D600491BCE /* ContainerViewControllerExample.swift */; };
 		35F3746D2F7F256800289195 /* ExampleAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F3746C2F7F256800289195 /* ExampleAsset.swift */; };
 		35F3746F2F7F256900289195 /* AssetDownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F3746E2F7F256900289195 /* AssetDownloadState.swift */; };
-		35F374712F7F258F00289195 /* OfflineDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F374702F7F258F00289195 /* OfflineDownloadManager.swift */; };
+		35F374712F7F258F00289195 /* ExampleOfflineDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F374702F7F258F00289195 /* ExampleOfflineDownloadManager.swift */; };
 		35F374732F7F25A000289195 /* DownloadAssetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F374722F7F25A000289195 /* DownloadAssetRow.swift */; };
 		35F374752F7F25AC00289195 /* AssetSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F374742F7F25AC00289195 /* AssetSelectionView.swift */; };
 		35F374772F7F25C500289195 /* OfflineAccessExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F374762F7F25C500289195 /* OfflineAccessExampleView.swift */; };
@@ -71,7 +71,7 @@
 		359DA8032EE8F8D600491BCE /* ContainerViewControllerExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerViewControllerExample.swift; sourceTree = "<group>"; };
 		35F3746C2F7F256800289195 /* ExampleAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleAsset.swift; sourceTree = "<group>"; };
 		35F3746E2F7F256900289195 /* AssetDownloadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDownloadState.swift; sourceTree = "<group>"; };
-		35F374702F7F258F00289195 /* OfflineDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDownloadManager.swift; sourceTree = "<group>"; };
+		35F374702F7F258F00289195 /* ExampleOfflineDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleOfflineDownloadManager.swift; sourceTree = "<group>"; };
 		35F374722F7F25A000289195 /* DownloadAssetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadAssetRow.swift; sourceTree = "<group>"; };
 		35F374742F7F25AC00289195 /* AssetSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSelectionView.swift; sourceTree = "<group>"; };
 		35F374762F7F25C500289195 /* OfflineAccessExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineAccessExampleView.swift; sourceTree = "<group>"; };
@@ -169,7 +169,7 @@
 				35FF85852F85892B00ECCF43 /* PlayerViewControllerRepresentable.swift */,
 				35F3746C2F7F256800289195 /* ExampleAsset.swift */,
 				35F3746E2F7F256900289195 /* AssetDownloadState.swift */,
-				35F374702F7F258F00289195 /* OfflineDownloadManager.swift */,
+				35F374702F7F258F00289195 /* ExampleOfflineDownloadManager.swift */,
 				35F374722F7F25A000289195 /* DownloadAssetRow.swift */,
 				35F374742F7F25AC00289195 /* AssetSelectionView.swift */,
 				35F374762F7F25C500289195 /* OfflineAccessExampleView.swift */,
@@ -327,7 +327,7 @@
 				1966C5302BEB4740005486D5 /* ProcessInfo+EnvironmentVariables.swift in Sources */,
 				35FF85862F85893400ECCF43 /* PlayerViewControllerRepresentable.swift in Sources */,
 				35F3746F2F7F256900289195 /* AssetDownloadState.swift in Sources */,
-				35F374712F7F258F00289195 /* OfflineDownloadManager.swift in Sources */,
+				35F374712F7F258F00289195 /* ExampleOfflineDownloadManager.swift in Sources */,
 				193228BD2ACF6AC700966FE1 /* SceneDelegate.swift in Sources */,
 				35F3746D2F7F256800289195 /* ExampleAsset.swift in Sources */,
 				35F374732F7F25A000289195 /* DownloadAssetRow.swift in Sources */,

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/AssetDownloadState.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/AssetDownloadState.swift
@@ -9,6 +9,7 @@ enum AssetDownloadState {
     case notDownloaded
     case downloading(progress: Double)
     case downloaded(AVURLAsset)
+    case expired
     case mustRedownload
     case error(Error)
 }

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/DownloadAssetRow.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/DownloadAssetRow.swift
@@ -53,6 +53,9 @@ struct DownloadAssetRow: View {
         case .downloaded:
             Image(systemName: "play.circle.fill")
                 .foregroundStyle(.blue)
+        case .expired:
+            Image(systemName: "clock.badge.exclamationmark")
+                .foregroundStyle(.orange)
         case .mustRedownload:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
@@ -77,6 +80,10 @@ struct DownloadAssetRow: View {
             Text("Downloaded")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+        case .expired:
+            Text("Expired")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
         case .mustRedownload:
             Text("Must Redownload")
                 .font(.subheadline)
@@ -99,7 +106,7 @@ struct DownloadAssetRow: View {
         case .downloaded:
             Button("Delete", role: .destructive) { onAction() }
                 .buttonStyle(.borderless)
-        case .mustRedownload, .error:
+        case .expired, .mustRedownload, .error:
             if let onSecondaryAction {
                 Button("Cancel", role: .destructive) { onSecondaryAction() }
                     .buttonStyle(.borderless)

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleAsset.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleAsset.swift
@@ -8,10 +8,23 @@ import Foundation
 struct ExampleAsset: Identifiable {
     let playbackID: String
     let title: String
-    let languages: String? = nil
-
-    let playbackToken: String? = nil
-    let drmToken: String? = nil
+    let languages: String?
+    let playbackToken: String?
+    let drmToken: String?
 
     var id: String { playbackID }
+
+    init(
+        playbackID: String,
+        title: String,
+        languages: String? = nil,
+        playbackToken: String? = nil,
+        drmToken: String? = nil
+    ) {
+        self.playbackID = playbackID
+        self.title = title
+        self.languages = languages
+        self.playbackToken = playbackToken
+        self.drmToken = drmToken
+    }
 }

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleOfflineDownloadManager.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleOfflineDownloadManager.swift
@@ -7,7 +7,7 @@ import AVFoundation
 import MuxPlayerSwift
 
 @MainActor
-final class OfflineDownloadManager: ObservableObject {
+final class ExampleOfflineDownloadManager: ObservableObject {
 
     // In your app, this would probably come from your app's backend or CMS
     let exampleAssets: [ExampleAsset] = [
@@ -48,8 +48,10 @@ final class OfflineDownloadManager: ObservableObject {
             switch asset.assetStatus {
             case .playable(let avAsset):
                 downloadStates[asset.playbackID] = .downloaded(avAsset)
-            case .redownloadWhenOnline, .expired:
+            case .redownloadWhenOnline:
                 downloadStates[asset.playbackID] = .mustRedownload
+            case .expired:
+                downloadStates[asset.playbackID] = .expired
             }
         }
 
@@ -63,9 +65,21 @@ final class OfflineDownloadManager: ObservableObject {
     // MARK: - Download Actions
 
     func startDownload(for asset: ExampleAsset) async {
+        let playbackOptions = {
+            if let playbackToken = asset.playbackToken {
+                if let drmToken = asset.drmToken {
+                    return PlaybackOptions(playbackToken: playbackToken, drmToken: drmToken)
+                } else {
+                    return PlaybackOptions(playbackToken: playbackToken)
+                }
+            } else {
+                return PlaybackOptions()
+            }
+        }()
+        
         let stream = await MuxOfflineAccessManager.shared.startDownload(
             playbackID: asset.playbackID,
-            playbackOptions: .init(),
+            playbackOptions: playbackOptions,
             downloadOptions: DownloadOptions(readableTitle: asset.title)
         )
         downloadStates[asset.playbackID] = .downloading(progress: 0.0)

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleOfflineDownloadManager.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleOfflineDownloadManager.swift
@@ -63,7 +63,11 @@ final class ExampleOfflineDownloadManager: ObservableObject {
     }
 
     // MARK: - Download Actions
-
+    
+    func removeDownload(playbackID: String) async {
+        await MuxOfflineAccessManager.shared.removeDownload(playbackID: playbackID)
+    }
+    
     func startDownload(for asset: ExampleAsset) async {
         let playbackOptions = {
             if let playbackToken = asset.playbackToken {

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/OfflineAccessExampleView.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/OfflineAccessExampleView.swift
@@ -9,7 +9,7 @@ import MuxPlayerSwift
 import SwiftUI
 
 struct OfflineAccessExampleView: View {
-    @StateObject private var manager = OfflineDownloadManager()
+    @StateObject private var manager = ExampleOfflineDownloadManager()
     @State private var playerToPresent: AVPlayer?
 
     var body: some View {
@@ -63,13 +63,16 @@ struct OfflineAccessExampleView: View {
         asset: ExampleAsset?
     ) -> some View {
         switch state {
-        case .mustRedownload, .error:
+        case .expired, .mustRedownload, .error:
             if let asset {
                 DownloadAssetRow(
                     title: asset.title,
                     state: state,
                     onAction: {
-                        Task { await manager.startDownload(for: asset) }
+                        Task {
+                            await MuxOfflineAccessManager.shared.removeDownload(playbackID: playbackID)
+                            await manager.startDownload(for: asset)
+                        }
                     },
                     onSecondaryAction: {
                         manager.cancelOrDeleteDownload(for: playbackID)

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/OfflineAccessExampleView.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/OfflineAccessExampleView.swift
@@ -70,7 +70,7 @@ struct OfflineAccessExampleView: View {
                     state: state,
                     onAction: {
                         Task {
-                            await MuxOfflineAccessManager.shared.removeDownload(playbackID: playbackID)
+                            await manager.removeDownload(playbackID: playbackID)
                             await manager.startDownload(for: asset)
                         }
                     },

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -57,7 +57,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         logger.trace("contentKeySession: didUpdatePersistableContentKey")
         Task {
             do {
-                await try handleContentKeyUpdated(keyIdentifier: keyIdentifier, data: persistableContentKey)
+                try await handleContentKeyUpdated(keyIdentifier: keyIdentifier, data: persistableContentKey)
             } catch {
                 // Delegate provides no way to notify of this
                 logger.error("Failed to update content key: \(error)")
@@ -229,7 +229,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
         
         // If we already have a persisted content key, use it (this is the offline playback path)
-        if let persistedContentKey = await try downloadManager.findPersistedContentKey(playbackID: playbackID) {
+        if let persistedContentKey = try await downloadManager.findPersistedContentKey(playbackID: playbackID) {
             // Transition to playDuration-based expiration on first offline playback
             await downloadManager.updateExpirationPhase(playbackID: playbackID, phase: .playDuration)
             request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistedContentKey))
@@ -246,7 +246,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
         
         let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
-        await try MuxOfflineAccessManager.shared.manager.savePersistedContentKey(
+        try await MuxOfflineAccessManager.shared.manager.savePersistedContentKey(
             playbackID: playbackID,
             identifier: requestIdentifierString,
             contentKeyData: persistableKey

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -33,6 +33,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         )
     }
     
+    func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVPersistableContentKeyRequest) {
+        // TODO: Have we a saved key blob for the playbackID and keyID? Return that, since we're trying to play
+        // otherwise....
+        // TODO: Normal workflow up to a point: App Cert from Mux -> makeRequestData from CDM -> CKC from Mux (don't give CKC to cdm yet)
+        // TODO: New workflow from here: CKC -> request.persistableContentKey(fromVendorblahblah) -> Some Key Blob -> processKeyResponse(thatKeyBlob) -> Save blob to disk
+    }
+    
     func contentKeySession(
         _ session: AVContentKeySession,
         didProvideRenewingContentKeyRequest keyRequest: AVContentKeyRequest
@@ -142,11 +149,25 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         logger.debug(
             "Called \(#function)"
         )
-
+        
         guard let sessionManager = self.sessionManager else {
             // TODO: Should this also invoke `processContentKeyResponseError`?
             logger.debug("Missing session manager")
             return
+        }
+        
+        // TODO: Do I care about keyID right now? I say playbackID is probably enough, since we don't support muli-key (and don't know if we'd support it via multiple skd urls if we chose to)
+        // TODO: For offline keys, Branch here (or around here)
+        // check - offline download started for a given playbackID+keyID || key blob already stored for given playbackID+keyID
+        if false /*TODO: Placeholder: sessionManager.isOfflineKeyRequest, checks drm_token and/or comes from different 'registry' (dict)*/ {
+            do {
+                try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
+                // no more processing for this key request. we'll get a delegate call with a persistable key request next
+                return
+            } catch {
+                // happens if playing airplay (according to example code). The proper response is to process as an online key
+                //  .. although using an 'offline' drm_token for playing an asset is technically not supported
+            }
         }
 
         // for hls, "the identifier must be an NSURL that matches a key URI in the Media Playlist." from the docs
@@ -160,7 +181,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             )
             return
         }
-
+        
         guard let playbackID = parsePlaybackId(
             fromSkdLocation: mediaPlaylistKeyURL
         ) else {
@@ -297,10 +318,15 @@ protocol KeyRequest {
                                             contentIdentifier: Data?,
                                             options: [String : Any]?,
                                             completionHandler handler: @escaping (Data?, (any Error)?) -> Void)
+    // Delegates to different methods depending on which platform we're on
+    func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws
+    // note: key vendor response is a CKC for FairPlay
+    func persistableContentKey(fromKeyVendorResponse: Data, options: [String: Any])
 }
 
 // Wraps a real AVContentKeyRequest and straightforwardly delegates to it
 struct DefaultKeyRequest : KeyRequest {
+    
     typealias InnerRequest = AVContentKeyRequest
     
     var identifier: Any? {
@@ -333,6 +359,18 @@ struct DefaultKeyRequest : KeyRequest {
             options: options,
             completionHandler: handler
         )
+    }
+    
+    func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws {
+        #if os(iOS)
+        try self.request.respondByRequestingPersistableContentKeyRequestAndReturnError()
+        #else
+        try self.respondByRequestingPersistableContentKeyRequest()
+        #endif
+    }
+    
+    func persistableContentKey(fromKeyVendorResponse ckcData: Data, options: [String : Any]) {
+        self.persistableContentKey(fromKeyVendorResponse: ckcData, options: options)
     }
     
     let request: InnerRequest

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -9,28 +9,24 @@ import AVFoundation
 import Foundation
 import os
 
-protocol PersistedKeyStore {
-    func findPersistedContentKey(playbackID: String) async throws -> Data?
-    func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws
-    func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async
-}
-
-extension DownloadManager: PersistedKeyStore {}
-
 class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredentialClient & DRMAssetRegistry> : NSObject, AVContentKeySessionDelegate {
 
     weak var sessionManager: SessionManager?
     var logger: Logger
 
-    private let persistedKeyStore: PersistedKeyStore
+    private let _persistedKeyStore: PersistedKeyStore?
+
+    private var persistedKeyStore: PersistedKeyStore {
+        _persistedKeyStore ?? MuxOfflineAccessManager.shared.manager
+    }
 
     init(
         sessionManager: SessionManager,
-        persistedKeyStore: PersistedKeyStore = MuxOfflineAccessManager.shared.manager
+        persistedKeyStore: PersistedKeyStore? = nil
     ) {
         self.sessionManager = sessionManager
         self.logger = sessionManager.logger
-        self.persistedKeyStore = persistedKeyStore
+        self._persistedKeyStore = persistedKeyStore
     }
     
     // MARK: AVContentKeySessionDelegate implementation

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -253,8 +253,6 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         )
         
         request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey))
-        
-        // TODO: Start removing DRMConfigs when we complete the handshake process
     }
     
     func handleContentKeyRequest(request: any KeyRequest) {

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -9,21 +9,28 @@ import AVFoundation
 import Foundation
 import os
 
+protocol PersistedKeyStore {
+    func findPersistedContentKey(playbackID: String) async throws -> Data?
+    func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws
+    func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async
+}
+
+extension DownloadManager: PersistedKeyStore {}
+
 class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredentialClient & DRMAssetRegistry> : NSObject, AVContentKeySessionDelegate {
-    
+
     weak var sessionManager: SessionManager?
     var logger: Logger
-    
-    private var downloadManager: DownloadManager {
-        // TODO: Manager ref should come from PlayerSDK, but making it TaskLocal would break stuff..
-        MuxOfflineAccessManager.shared.manager
-    }
+
+    private let persistedKeyStore: PersistedKeyStore
 
     init(
-        sessionManager: SessionManager
+        sessionManager: SessionManager,
+        persistedKeyStore: PersistedKeyStore = MuxOfflineAccessManager.shared.manager
     ) {
         self.sessionManager = sessionManager
         self.logger = sessionManager.logger
+        self.persistedKeyStore = persistedKeyStore
     }
     
     // MARK: AVContentKeySessionDelegate implementation
@@ -193,7 +200,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             return
         }
         
-        try await downloadManager.savePersistedContentKey(
+        try await persistedKeyStore.savePersistedContentKey(
             playbackID: playbackID,
             identifier: requestIdentifierString,
             contentKeyData: data
@@ -228,10 +235,12 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
         
         // If we already have a persisted content key, use it (this is the offline playback path)
-        if let persistedContentKey = try await downloadManager.findPersistedContentKey(playbackID: playbackID) {
+        if let persistedContentKey = try await persistedKeyStore.findPersistedContentKey(playbackID: playbackID) {
             // Transition to playDuration-based expiration on first offline playback
-            await downloadManager.updateExpirationPhase(playbackID: playbackID, phase: .playDuration)
-            request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistedContentKey))
+            await persistedKeyStore.updateExpirationPhase(playbackID: playbackID, phase: .playDuration)
+            request.processContentKeyResponse(
+                request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: persistedContentKey)
+            )
             return
         }
 
@@ -245,13 +254,15 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
         
         let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
-        try await MuxOfflineAccessManager.shared.manager.savePersistedContentKey(
+        try await persistedKeyStore.savePersistedContentKey(
             playbackID: playbackID,
             identifier: requestIdentifierString,
             contentKeyData: persistableKey
         )
         
-        request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey))
+        request.processContentKeyResponse(
+            request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey)
+        )
     }
     
     func handleContentKeyRequest(request: any KeyRequest) {
@@ -396,7 +407,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             logger.debug("Submitting CKC to system")
             // Send CKC to CDM/wherever else so we can finally play our content
             let keyResponse = request.makeContentKeyResponse(
-                data: ckcData
+                fairPlayStreamingKeyResponseData: ckcData
             )
             request.processContentKeyResponse(
                 keyResponse
@@ -415,7 +426,7 @@ protocol KeyRequest {
     
     var identifier: Any? { get }
     
-    func makeContentKeyResponse(data: Data) -> AVContentKeyResponse
+    func makeContentKeyResponse(fairPlayStreamingKeyResponseData data: Data) -> AVContentKeyResponse
     
     func processContentKeyResponse(_ response: AVContentKeyResponse)
     func processContentKeyResponseError(_ error: any Error)
@@ -433,6 +444,7 @@ protocol KeyRequest {
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws
     // note: key vendor response is a CKC for FairPlay
     func persistableContentKey(fromKeyVendorResponse: Data, options: [String: Any]?) throws -> Data
+    func createPersistableKeyResponse(data: Data) -> AVContentKeyResponse
 }
 
 // Wraps a real AVContentKeyRequest and straightforwardly delegates to it
@@ -446,7 +458,7 @@ struct DefaultKeyRequest : KeyRequest {
         }
     }
     
-    func makeContentKeyResponse(data: Data) -> AVContentKeyResponse {
+    func makeContentKeyResponse(fairPlayStreamingKeyResponseData data: Data) -> AVContentKeyResponse {
         return AVContentKeyResponse(fairPlayStreamingKeyResponseData: data)
     }
     
@@ -505,13 +517,17 @@ struct DefaultKeyRequest : KeyRequest {
         guard let persistableKeyRequest = self.request as? AVPersistableContentKeyRequest else {
             throw FairPlaySessionError.unexpected(message: "Attempted to process streaming key request as persistable request")
         }
-        
+
         return try persistableKeyRequest.persistableContentKey(
             fromKeyVendorResponse: fromKeyVendorResponse,
             options: options
         )
     }
-    
+
+    func createPersistableKeyResponse(data: Data) -> AVContentKeyResponse {
+        return AVContentKeyResponse(fairPlayStreamingKeyResponseData: data)
+    }
+
     let request: InnerRequest
     
     init(wrapping request: InnerRequest) {

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -261,7 +261,6 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         )
         
         guard let sessionManager = self.sessionManager else {
-            // TODO: Should this also invoke `processContentKeyResponseError`?
             logger.debug("Missing session manager")
             return
         }
@@ -271,7 +270,6 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
               let mediaPlaylistKeyURL = URL(string: requestIdentifierString),
               let utfEncodedRequestIdentifierString = requestIdentifierString.data(using: .utf8)
         else {
-            // TODO: Should this also invoke `processContentKeyResponseError`?
             logger.debug(
                 "CK request identifier not a valid key url."
             )

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -229,7 +229,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
         
         // If we already have a persisted content key, use it (this is the offline playback path)
-        if let persistedContentKey = await try downloadManager.findPeristedContentKey(playbackID: playbackID) {
+        if let persistedContentKey = await try downloadManager.findPersistedContentKey(playbackID: playbackID) {
             // Transition to playDuration-based expiration on first offline playback
             await downloadManager.updateExpirationPhase(playbackID: playbackID, phase: .playDuration)
             request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistedContentKey))

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -177,8 +177,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
     ) async throws {
         logger.trace("\(#function) called")
         guard let requestIdentifierString = keyIdentifier as? String,
-              let mediaPlaylistKeyURL = URL(string: requestIdentifierString),
-              let utfEncodedRequestIdentifierString = requestIdentifierString.data(using: .utf8)
+              let mediaPlaylistKeyURL = URL(string: requestIdentifierString)
         else {
             // TODO: Should this also invoke `processContentKeyResponseError`?
             logger.debug(

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -440,7 +440,6 @@ protocol KeyRequest {
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws
     // note: key vendor response is a CKC for FairPlay
     func persistableContentKey(fromKeyVendorResponse: Data, options: [String: Any]?) throws -> Data
-    func createPersistableKeyResponse(data: Data) -> AVContentKeyResponse
 }
 
 // Wraps a real AVContentKeyRequest and straightforwardly delegates to it
@@ -518,10 +517,6 @@ struct DefaultKeyRequest : KeyRequest {
             fromKeyVendorResponse: fromKeyVendorResponse,
             options: options
         )
-    }
-
-    func createPersistableKeyResponse(data: Data) -> AVContentKeyResponse {
-        return AVContentKeyResponse(fairPlayStreamingKeyResponseData: data)
     }
 
     let request: InnerRequest

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -36,9 +36,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         didProvide keyRequest: AVContentKeyRequest
     ) {
         logger.trace("didProvide AVContentKeyRequest")
-        handleContentKeyRequest(
-            request: DefaultKeyRequest(wrapping: keyRequest)
-        )
+        Task {
+            do {
+                try await handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+            } catch {
+                keyRequest.processContentKeyResponseError(error)
+            }
+        }
     }
     
     func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVPersistableContentKeyRequest) {
@@ -73,7 +77,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         didProvideRenewingContentKeyRequest keyRequest: AVContentKeyRequest
     ) {
         logger.trace("didProvide didProvideRenewingContentKeyRequest")
-        handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+        Task {
+            do {
+                try await handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+            } catch {
+                keyRequest.processContentKeyResponseError(error)
+            }
+        }
     }
     
     func contentKeySession(
@@ -241,13 +251,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
 
         // No content key already? Try to get one
-        let appCertData = try await sessionManager.requestCertificate(playbackID: playbackID)
+        let appCertData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: true)
         let spcData = try await request.makeStreamingContentKeyRequestData(
             forApp: appCertData,
             contentIdentifier: utfEncodedRequestIdentifierString,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
         )
-        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: true)
         
         let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
         try await persistedKeyStore.savePersistedContentKey(
@@ -261,7 +271,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         )
     }
     
-    func handleContentKeyRequest(request: any KeyRequest) {
+    func handleContentKeyRequest(request: any KeyRequest) async throws {
         logger.debug(
             "Called \(#function)"
         )
@@ -295,7 +305,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
         
         // Check for offline - if this is for offline, we trigger the persistable content key flow
-        if sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
+        if await sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
             do {
                 try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
                 // no more processing for this key request. we'll get a delegate call with a persistable key request next
@@ -305,113 +315,27 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
                 //  .. although using an 'offline' drm_token for playing an asset is technically not supported
             }
         }
-
-        // get app cert
-        sessionManager.requestCertificate(
-            playbackID: playbackID,
-            completion: { [weak self] result in
-                guard let self else {
-                    PlayerSDK.shared.diagnosticsLogger.debug(
-                        "Content key request completed: missing session delegate"
-                    )
-                    return
-                }
-
-                let applicationCertificate: Data
-                do {
-                    applicationCertificate = try result.get()
-                } catch {
-                    request.processContentKeyResponseError(
-                        error
-                    )
-                    return
-                }
-
-                handleApplicationCertificate(
-                    applicationCertificate,
-                    contentIdentifier: utfEncodedRequestIdentifierString,
-                    playbackID: playbackID,
-                    request: request)
-            }
-        )
-    }
-
-    func handleApplicationCertificate(
-        _ applicationCertificate: Data,
-        contentIdentifier utfEncodedRequestIdentifierString: Data,
-        playbackID: String,
-        request: any KeyRequest
-    ) {
-        // exchange app cert for SPC using KeyRequest to give to CDM
-        request.makeStreamingContentKeyRequestData(
-            forApp: applicationCertificate,
+        
+        // If we're not playing offline, do the handshake for an online key request
+        let certData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: false)
+        let spcData = try await request.makeStreamingContentKeyRequestData(
+            forApp: certData,
             contentIdentifier: utfEncodedRequestIdentifierString,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
-        ) { [weak self] spcData, error in
-            guard let self = self else {
-                PlayerSDK.shared.diagnosticsLogger.debug(
-                    "Content key request completed: missing session delegate"
-                )
-                return
-            }
-            
-            guard let spcData = spcData else {
-                request.processContentKeyResponseError(
-                    error ?? FairPlaySessionError.unexpected(message: "no SPC")
-                )
-                return
-            }
-            
-            // exchange SPC for CKC
-            handleSpcObtainedFromCDMForOnlineKey(
-                spcData: spcData,
-                playbackID: playbackID,
-                request: request
-            )
-        }
-    }
-    
-    func handleSpcObtainedFromCDMForOnlineKey(
-        spcData: Data,
-        playbackID: String,
-        request: any KeyRequest
-    ) {
-        guard let sessionManager = self.sessionManager else {
-            logger.debug("Missing Session Manager")
-            return
-        }
+        )
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: false)
         
-        sessionManager.requestLicense(
-            spcData: spcData,
-            playbackID: playbackID,
-            offline: false
-        ) { [weak self] result in
-            guard let self else {
-                return
-            }
-
-            let ckcData: Data
-            do {
-                ckcData = try result.get()
-            } catch {
-                request.processContentKeyResponseError(
-                    error
-                )
-                return
-            }
-
-            logger.debug("Submitting CKC to system")
-            // Send CKC to CDM/wherever else so we can finally play our content
-            let keyResponse = request.makeContentKeyResponse(
-                fairPlayStreamingKeyResponseData: ckcData
-            )
-            request.processContentKeyResponse(
-                keyResponse
-            )
-            logger.debug("Protected content now available for processing")
-            // Done! no further interaction is required from us to play.
-        }
-    }
+        // Send CKC to CDM/ContentKeySession so we can finally play our content
+        logger.debug("Submitting CKC to system")
+        let keyResponse = request.makeContentKeyResponse(
+            fairPlayStreamingKeyResponseData: ckcData
+        )
+        request.processContentKeyResponse(
+            keyResponse
+        )
+        logger.debug("Protected content now available for processing")
+        // Done! no further interaction is required from us to play.
+   }
 }
 
 // Wraps a generic request for a key and delegates calls to it

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -9,11 +9,15 @@ import AVFoundation
 import Foundation
 import os
 
-class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredentialClient> : NSObject, AVContentKeySessionDelegate {
+class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredentialClient & DRMAssetRegistry> : NSObject, AVContentKeySessionDelegate {
     
     weak var sessionManager: SessionManager?
-
     var logger: Logger
+    
+    private var downloadManager: DownloadManager {
+        // TODO: Manager ref should come from PlayerSDK, but making it TaskLocal would break stuff..
+        MuxOfflineAccessManager.shared.manager
+    }
 
     init(
         sessionManager: SessionManager
@@ -28,22 +32,44 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         _ session: AVContentKeySession,
         didProvide keyRequest: AVContentKeyRequest
     ) {
+        logger.trace("didProvide AVContentKeyRequest")
         handleContentKeyRequest(
             request: DefaultKeyRequest(wrapping: keyRequest)
         )
     }
     
     func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVPersistableContentKeyRequest) {
-        // TODO: Have we a saved key blob for the playbackID and keyID? Return that, since we're trying to play
-        // otherwise....
-        // TODO: Normal workflow up to a point: App Cert from Mux -> makeRequestData from CDM -> CKC from Mux (don't give CKC to cdm yet)
-        // TODO: New workflow from here: CKC -> request.persistableContentKey(fromVendorblahblah) -> Some Key Blob -> processKeyResponse(thatKeyBlob) -> Save blob to disk
+        logger.trace("didProvide AVPersistableContentKeyRequest")
+        Task {
+            do {
+                try await handlePersistableContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+            } catch {
+                keyRequest.processContentKeyResponseError(error)
+            }
+        }
+    }
+    
+    func contentKeySession(
+        _ session: AVContentKeySession,
+        didUpdatePersistableContentKey persistableContentKey: Data,
+        forContentKeyIdentifier keyIdentifier: Any
+    ) {
+        logger.trace("contentKeySession: didUpdatePersistableContentKey")
+        Task {
+            do {
+                await try handleContentKeyUpdated(keyIdentifier: keyIdentifier, data: persistableContentKey)
+            } catch {
+                // Delegate provides no way to notify of this
+                logger.error("Failed to update content key: \(error)")
+            }
+        }
     }
     
     func contentKeySession(
         _ session: AVContentKeySession,
         didProvideRenewingContentKeyRequest keyRequest: AVContentKeyRequest
     ) {
+        logger.trace("didProvide didProvideRenewingContentKeyRequest")
         handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
     }
     
@@ -145,6 +171,92 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         )
     }
     
+    func handleContentKeyUpdated(
+        keyIdentifier: Any,
+        data: Data
+    ) async throws {
+        logger.trace("\(#function) called")
+        guard let requestIdentifierString = keyIdentifier as? String,
+              let mediaPlaylistKeyURL = URL(string: requestIdentifierString),
+              let utfEncodedRequestIdentifierString = requestIdentifierString.data(using: .utf8)
+        else {
+            // TODO: Should this also invoke `processContentKeyResponseError`?
+            logger.debug(
+                "CK request identifier not a valid key url."
+            )
+            return
+        }
+        
+        guard let playbackID = parsePlaybackId(
+            fromSkdLocation: mediaPlaylistKeyURL
+        ) else {
+            logger.debug("\(#function) Error: key SKD location missing playbackId [\(mediaPlaylistKeyURL.absoluteString)]")
+            return
+        }
+        
+        try await downloadManager.savePersistedContentKey(
+            playbackID: playbackID,
+            identifier: requestIdentifierString,
+            contentKeyData: data
+        )
+    }
+    
+    func handlePersistableContentKeyRequest(request: any KeyRequest) async throws {
+        logger.trace("\(#function) called")
+        
+        guard let sessionManager = self.sessionManager else {
+            // could happen if recovering from media services crashing
+            throw FairPlaySessionError.unexpected(message: "\(#function) called with terminated SessionManager")
+        }
+        
+        // for hls, "the identifier must be an NSURL that matches a key URI in the Media Playlist." from the docs
+        guard let requestIdentifierString = request.identifier as? String,
+              let mediaPlaylistKeyURL = URL(string: requestIdentifierString),
+              let utfEncodedRequestIdentifierString = requestIdentifierString.data(using: .utf8)
+        else {
+            // TODO: Should this also invoke `processContentKeyResponseError`?
+            logger.debug(
+                "CK request identifier not a valid key url."
+            )
+            return
+        }
+        
+        guard let playbackID = parsePlaybackId(
+            fromSkdLocation: mediaPlaylistKeyURL
+        ) else {
+            logger.debug("\(#function) Error: key SKD location missing playbackId [\(mediaPlaylistKeyURL.absoluteString)]")
+            throw FairPlaySessionError.unexpected(message: "playbackID not present in key uri")
+        }
+        
+        // If we already have a persisted content key, use it (this is the offline playback path)
+        if let persistedContentKey = await try downloadManager.findPeristedContentKey(playbackID: playbackID) {
+            // Transition to playDuration-based expiration on first offline playback
+            await downloadManager.updateExpirationPhase(playbackID: playbackID, phase: .playDuration)
+            request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistedContentKey))
+            return
+        }
+
+        // No content key already? Try to get one
+        let appCertData = try await sessionManager.requestCertificate(playbackID: playbackID)
+        let spcData = try await request.makeStreamingContentKeyRequestData(
+            forApp: appCertData,
+            contentIdentifier: utfEncodedRequestIdentifierString,
+            options: [AVContentKeyRequestProtocolVersionsKey: [1]]
+        )
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
+        
+        let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
+        await try MuxOfflineAccessManager.shared.manager.savePersistedContentKey(
+            playbackID: playbackID,
+            identifier: requestIdentifierString,
+            contentKeyData: persistableKey
+        )
+        
+        request.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey))
+        
+        // TODO: Start removing DRMConfigs when we complete the handshake process
+    }
+    
     func handleContentKeyRequest(request: any KeyRequest) {
         logger.debug(
             "Called \(#function)"
@@ -154,20 +266,6 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             // TODO: Should this also invoke `processContentKeyResponseError`?
             logger.debug("Missing session manager")
             return
-        }
-        
-        // TODO: Do I care about keyID right now? I say playbackID is probably enough, since we don't support muli-key (and don't know if we'd support it via multiple skd urls if we chose to)
-        // TODO: For offline keys, Branch here (or around here)
-        // check - offline download started for a given playbackID+keyID || key blob already stored for given playbackID+keyID
-        if false /*TODO: Placeholder: sessionManager.isOfflineKeyRequest, checks drm_token and/or comes from different 'registry' (dict)*/ {
-            do {
-                try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
-                // no more processing for this key request. we'll get a delegate call with a persistable key request next
-                return
-            } catch {
-                // happens if playing airplay (according to example code). The proper response is to process as an online key
-                //  .. although using an 'offline' drm_token for playing an asset is technically not supported
-            }
         }
 
         // for hls, "the identifier must be an NSURL that matches a key URI in the Media Playlist." from the docs
@@ -192,6 +290,18 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             )
             logger.debug("\(#function) Error: key url SDK location missing playbackId [\(mediaPlaylistKeyURL.absoluteString)]")
             return
+        }
+        
+        // Check for offline - if this is for offline, we trigger the persistable content key flow
+        if sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
+            do {
+                try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
+                // no more processing for this key request. we'll get a delegate call with a persistable key request next
+                return
+            } catch {
+                // happens if playing airplay (according to example code). The proper response is to process as an online key
+                //  .. although using an 'offline' drm_token for playing an asset is technically not supported
+            }
         }
 
         // get app cert
@@ -251,7 +361,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             }
             
             // exchange SPC for CKC
-            handleSpcObtainedFromCDM(
+            handleSpcObtainedFromCDMForOnlineKey(
                 spcData: spcData,
                 playbackID: playbackID,
                 request: request
@@ -259,7 +369,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
     }
     
-    func handleSpcObtainedFromCDM(
+    func handleSpcObtainedFromCDMForOnlineKey(
         spcData: Data,
         playbackID: String,
         request: any KeyRequest
@@ -318,10 +428,16 @@ protocol KeyRequest {
                                             contentIdentifier: Data?,
                                             options: [String : Any]?,
                                             completionHandler handler: @escaping (Data?, (any Error)?) -> Void)
+    
+    func makeStreamingContentKeyRequestData(forApp appIdentifier: Data,
+                                            contentIdentifier: Data?,
+                                            options: [String : Any]?
+    ) async throws -> Data
+
     // Delegates to different methods depending on which platform we're on
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws
     // note: key vendor response is a CKC for FairPlay
-    func persistableContentKey(fromKeyVendorResponse: Data, options: [String: Any])
+    func persistableContentKey(fromKeyVendorResponse: Data, options: [String: Any]?) throws -> Data
 }
 
 // Wraps a real AVContentKeyRequest and straightforwardly delegates to it
@@ -361,16 +477,44 @@ struct DefaultKeyRequest : KeyRequest {
         )
     }
     
+    func makeStreamingContentKeyRequestData(
+        forApp appIdentifier: Data,
+        contentIdentifier: Data?,
+        options: [String : Any]? = nil
+    ) async throws -> Data {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.request.makeStreamingContentKeyRequestData(
+                forApp: appIdentifier, contentIdentifier: contentIdentifier
+            ) { data, error in
+                if let data {
+                    continuation.resume(returning: data)
+                } else if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    // probably not a real case, but we don't want to hang the request to the system
+                    continuation.resume(throwing: FairPlaySessionError.unexpected(message: "No SPC data or error"))
+                }
+            }
+        }
+    }
+    
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws {
         #if os(iOS)
         try self.request.respondByRequestingPersistableContentKeyRequestAndReturnError()
         #else
-        try self.respondByRequestingPersistableContentKeyRequest()
+        try self.request.respondByRequestingPersistableContentKeyRequest()
         #endif
     }
     
-    func persistableContentKey(fromKeyVendorResponse ckcData: Data, options: [String : Any]) {
-        self.persistableContentKey(fromKeyVendorResponse: ckcData, options: options)
+    func persistableContentKey(fromKeyVendorResponse: Data, options: [String: Any]?) throws -> Data {
+        guard let persistableKeyRequest = self.request as? AVPersistableContentKeyRequest else {
+            throw FairPlaySessionError.unexpected(message: "Attempted to process streaming key request as persistable request")
+        }
+        
+        return try persistableKeyRequest.persistableContentKey(
+            fromKeyVendorResponse: fromKeyVendorResponse,
+            options: options
+        )
     }
     
     let request: InnerRequest

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -145,7 +145,12 @@ class DefaultFairPlayStreamingSessionManager<
     
     private func offlineDRMConfigOnQueue(for playbackID: String) async -> DRMConfig? {
         return await withCheckedContinuation { continuation in
-            queue.async { [offlineDownloadKeyLookup] in
+            queue.async { [logger, weak self] in
+                guard let self else {
+                    logger.warning("looked up offline DRMConfig after cleanup")
+                    continuation.resume(returning: nil)
+                    return
+                }
                 continuation.resume(returning: offlineDownloadKeyLookup[playbackID])
             }
         }

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -30,6 +30,10 @@ protocol FairPlayStreamingSessionCredentialClient: AnyObject {
         offline _: Bool,
         completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
     )
+    
+    func requestCertificate(playbackID: String) async throws -> Data
+    
+    func requestLicence(spcData: Data, playbackID: String) async throws -> Data
 
     var logger: Logger { get set }
 }
@@ -37,6 +41,12 @@ protocol FairPlayStreamingSessionCredentialClient: AnyObject {
 // Intended for registering drm-protected AVURLAssets
 protocol DRMAssetRegistry {
     func addDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String)
+
+    func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String)
+    func removeOfflineDownloadSession(playbackID: String)
+    func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async
+    func hasOfflineDRMConfig(playbackID: String) -> Bool
+    func offlineKeyData(playbackID: String) -> Data?
 }
 
 // MARK: - FairPlayStreamingSessionManager
@@ -74,6 +84,7 @@ extension AVContentKeySession: ContentKeyProvider {
 class DefaultFairPlayStreamingSessionManager<
     ContentKeySession: ContentKeyProvider
 >: FairPlayStreamingSessionManager {
+    
     private let queue: DispatchQueue
 
     private var notificationObservers = [NSObjectProtocol]()
@@ -82,8 +93,20 @@ class DefaultFairPlayStreamingSessionManager<
         let options: PlaybackOptions.DRMPlaybackOptions
         let rootDomain: String
     }
-    /// should be accessed on `queue`
-    private var configLookup: [String: DRMConfig] = [:]
+    /// should be accessed on `queue`. Used for the online drm key-fetching flow
+    private var onlineKeyConfigLookup: [String: DRMConfig] = [:]
+    /// should be accessed on `queue`. Used for the offline-download key-fetching flow
+    private var offlineDownloadKeyLookup: [String: DRMConfig] = [:]
+    /// should be accessed on `queue`. Used for the offline-download key-fetching flow
+    private var offlinePlayLookup: [String: Data] = [:]
+    /// should be accessed on `queue`. Per-download content key sessions,
+    /// keyed by playbackID. Each download gets its own session so
+    /// re-downloads can trigger a fresh key request flow.
+    private var downloadKeySessions: [String: ContentKeySession] = [:]
+    /// should be accessed on `queue`. Delegates for per-download sessions.
+    /// Stored to prevent deallocation since AVContentKeySession holds a
+    /// weak reference to its delegate.
+    private var downloadKeyDelegates: [String: AVContentKeySessionDelegate] = [:]
 
     private var contentKeySession: ContentKeySession {
         willSet {
@@ -120,14 +143,66 @@ class DefaultFairPlayStreamingSessionManager<
 
     private let urlSession: URLSession
     
+    private func offlineDRMConfigOnQueue(for playbackID: String) async -> DRMConfig? {
+        return await withCheckedContinuation { continuation in
+            queue.async { [logger, weak self] in
+                guard let self else {
+                    logger.warning("looked up offline DRMConfig after cleanup")
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: offlineDownloadKeyLookup[playbackID])
+            }
+        }
+    }
+    
     // MARK: Requesting licenses and certs
     
-    /// Requests the App Certificate for a playback id
+    func requestCertificate(playbackID: String) async throws -> Data {
+        guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
+            throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
+        }
+        
+        // TODO: (future maintenance) request should be async by default, not completion handlers by default
+        return try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self = self else {
+                continuation.resume(throwing:
+                    FairPlaySessionError.unexpected(message: "SessionManager terminated while fetching app cert")
+                )
+                return
+            }
+            
+            self.requestCertificateInner(playbackID: playbackID, drmConfig: config) { continuation.resume(with: $0) }
+        }
+    }
+    
+    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
+        guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
+            throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
+        }
+        
+        // TODO: (future maintenance) request should be async by default, not completion handlers by default
+        return try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self else {
+                continuation.resume(throwing:
+                    FairPlaySessionError.unexpected(message: "SessionManager terminated while fetching license")
+                )
+                return
+            }
+            
+            self.requestLicenseInner(
+                spcData: spcData,
+                playbackID: playbackID,
+                drmConfig: config
+            ) { continuation.resume(with: $0) }
+        }
+    }
+    
     func requestCertificate(
         playbackID: String,
         completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
     ) {
-        guard let config = configLookup[playbackID] else {
+        guard let config = onlineKeyConfigLookup[playbackID] else {
             logger.debug(
                 "No registered DRM configuration for playbackID \(playbackID)."
             )
@@ -140,7 +215,39 @@ class DefaultFairPlayStreamingSessionManager<
             )
             return
         }
+        
+        requestCertificateInner(playbackID: playbackID, drmConfig: config, completion: requestCompletion)
+    }
 
+    func requestLicense(
+        spcData: Data,
+        playbackID: String,
+        offline: Bool,
+        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
+    ) {
+        guard let config = onlineKeyConfigLookup[playbackID] else {
+            logger.debug(
+                "No registered DRM configuration for playbackID \(playbackID)."
+            )
+            requestCompletion(
+                .failure(
+                    FairPlaySessionError.unexpected(
+                        message: "No registered DRM configuration for playbackID \(playbackID)"
+                    )
+                )
+            )
+            return
+        }
+        
+        requestLicenseInner(spcData: spcData, playbackID: playbackID, drmConfig: config, completion: requestCompletion)
+    }
+    
+    /// Requests the App Certificate for a playback id
+    private func requestCertificateInner(
+        playbackID: String,
+        drmConfig config: DRMConfig,
+        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
+    ) {
         let rootDomain = config.rootDomain
         let drmToken = config.options.drmToken
 
@@ -262,25 +369,12 @@ class DefaultFairPlayStreamingSessionManager<
     
     /// Requests a license to play based on the given SPC data
     /// - parameter offline - Not currently used, may not ever be used in short-term, maybe delete?
-    func requestLicense(
+    private func requestLicenseInner(
         spcData: Data,
         playbackID: String,
-        offline: Bool,
+        drmConfig config: DRMConfig,
         completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
     ) {
-        guard let config = configLookup[playbackID] else {
-            logger.debug(
-                "No registered DRM configuration for playbackID \(playbackID)."
-            )
-            requestCompletion(
-                .failure(
-                    FairPlaySessionError.unexpected(
-                        message: "No registered DRM configuration for playbackID \(playbackID)"
-                    )
-                )
-            )
-            return
-        }
 
         let drmToken = config.options.drmToken
         let rootDomain = config.rootDomain
@@ -397,18 +491,76 @@ class DefaultFairPlayStreamingSessionManager<
     ) {
         // contentKeySession delegate callbacks will eventually need this, submit before starting the flow
         queue.async { [weak self] in
-            self?.configLookup[playbackID] = DRMConfig(
+            self?.onlineKeyConfigLookup[playbackID] = DRMConfig(
                 options: options,
                 rootDomain: rootDomain)
         }
         contentKeySession.addContentKeyRecipient(urlAsset)
+    }
+    
+    func addOfflineDownloadDRMAsset(
+        _ urlAsset: AVURLAsset,
+        playbackID: String,
+        options: PlaybackOptions.DRMPlaybackOptions,
+        rootDomain: String
+    ) {
+        // Create a fresh session for this download so re-downloads
+        // always trigger a new key request flow
+        let downloadSession = contentKeySession.recreate()
+        let delegate = ContentKeySessionDelegate(sessionManager: self)
+        downloadSession.setDelegate(delegate, queue: queue)
+        queue.async { [weak self] in
+            self?.offlineDownloadKeyLookup[playbackID] = DRMConfig(
+                options: options,
+                rootDomain: rootDomain
+            )
+            self?.downloadKeySessions[playbackID] = downloadSession
+            self?.downloadKeyDelegates[playbackID] = delegate
+        }
+        downloadSession.addContentKeyRecipient(urlAsset)
+    }
+
+    func removeOfflineDownloadSession(playbackID: String) {
+        queue.async { [weak self] in
+            self?.downloadKeySessions[playbackID]?.setDelegate(nil, queue: nil)
+            self?.downloadKeySessions[playbackID] = nil
+            self?.downloadKeyDelegates[playbackID] = nil
+            self?.offlineDownloadKeyLookup[playbackID] = nil
+        }
+    }
+    
+    func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async {
+        await withCheckedContinuation { continuation in
+            queue.async { [weak self] in
+                self?.offlinePlayLookup[playbackID] = keyData
+                continuation.resume()
+            }
+        }
+        self.contentKeySession.addContentKeyRecipient(urlAsset)
+    }
+    
+    func hasOfflineDRMConfig(playbackID: String) -> Bool {
+        // called from ContentKeySessionDelegate, is definitely on .queue
+        return offlinePlayLookup[playbackID] != nil || offlineDownloadKeyLookup[playbackID] != nil
+    }
+    
+    func offlineKeyData(playbackID: String) -> Data? {
+        return offlinePlayLookup[playbackID]
     }
 
     // MARK: error recovery
 
     private func handleMediaServicesLost() {
         queue.async { [weak self] in
-            self?.configLookup.removeAll()
+            guard let self else { return }
+            self.onlineKeyConfigLookup.removeAll()
+            self.offlinePlayLookup.removeAll()
+            self.offlineDownloadKeyLookup.removeAll()
+            for (_, session) in self.downloadKeySessions {
+                session.setDelegate(nil, queue: nil)
+            }
+            self.downloadKeySessions.removeAll()
+            self.downloadKeyDelegates.removeAll()
         }
         contentKeySession = contentKeySession.recreate()
     }

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -145,12 +145,7 @@ class DefaultFairPlayStreamingSessionManager<
     
     private func offlineDRMConfigOnQueue(for playbackID: String) async -> DRMConfig? {
         return await withCheckedContinuation { continuation in
-            queue.async { [logger, weak self] in
-                guard let self else {
-                    logger.warning("looked up offline DRMConfig after cleanup")
-                    continuation.resume(returning: nil)
-                    return
-                }
+            queue.async { [offlineDownloadKeyLookup] in
                 continuation.resume(returning: offlineDownloadKeyLookup[playbackID])
             }
         }

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -17,23 +17,9 @@ import os
 protocol FairPlayStreamingSessionCredentialClient: AnyObject {
     // MARK: Requesting licenses and certs
 
-    // Requests the App Certificate for a playback id
-    func requestCertificate(
-        playbackID: String,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    )
-    // Requests a license to play based on the given SPC data
-    // - parameter offline - Not currently used, may not ever be used in short-term, maybe delete?
-    func requestLicense(
-        spcData: Data,
-        playbackID: String,
-        offline _: Bool,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    )
-    
-    func requestCertificate(playbackID: String) async throws -> Data
-    
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data
+
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data
 
     var logger: Logger { get set }
 }
@@ -45,7 +31,7 @@ protocol DRMAssetRegistry {
     func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String)
     func removeOfflineDownloadSession(playbackID: String)
     func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async
-    func hasOfflineDRMConfig(playbackID: String) -> Bool
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool
     func offlineKeyData(playbackID: String) -> Data?
 }
 
@@ -143,111 +129,43 @@ class DefaultFairPlayStreamingSessionManager<
 
     private let urlSession: URLSession
     
-    private func offlineDRMConfigOnQueue(for playbackID: String) async -> DRMConfig? {
+    private func drmConfigOnQueue(for playbackID: String, offline: Bool) async -> DRMConfig? {
         return await withCheckedContinuation { continuation in
             queue.async { [logger, weak self] in
                 guard let self else {
-                    logger.warning("looked up offline DRMConfig after cleanup")
+                    logger.warning("looked up DRMConfig after cleanup")
                     continuation.resume(returning: nil)
                     return
                 }
-                continuation.resume(returning: offlineDownloadKeyLookup[playbackID])
+                let lookup = offline ? offlineDownloadKeyLookup : onlineKeyConfigLookup
+                continuation.resume(returning: lookup[playbackID])
             }
         }
-    }
-    
-    // MARK: Requesting licenses and certs
-    
-    func requestCertificate(playbackID: String) async throws -> Data {
-        guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
-            throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
-        }
-        
-        // TODO: (future maintenance) request should be async by default, not completion handlers by default
-        return try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self = self else {
-                continuation.resume(throwing:
-                    FairPlaySessionError.unexpected(message: "SessionManager terminated while fetching app cert")
-                )
-                return
-            }
-            
-            self.requestCertificateInner(playbackID: playbackID, drmConfig: config) { continuation.resume(with: $0) }
-        }
-    }
-    
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
-        guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
-            throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
-        }
-        
-        // TODO: (future maintenance) request should be async by default, not completion handlers by default
-        return try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self else {
-                continuation.resume(throwing:
-                    FairPlaySessionError.unexpected(message: "SessionManager terminated while fetching license")
-                )
-                return
-            }
-            
-            self.requestLicenseInner(
-                spcData: spcData,
-                playbackID: playbackID,
-                drmConfig: config
-            ) { continuation.resume(with: $0) }
-        }
-    }
-    
-    func requestCertificate(
-        playbackID: String,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
-        guard let config = onlineKeyConfigLookup[playbackID] else {
-            logger.debug(
-                "No registered DRM configuration for playbackID \(playbackID)."
-            )
-            requestCompletion(
-                .failure(
-                    FairPlaySessionError.unexpected(
-                        message: "No registered DRM configuration for playbackID \(playbackID)"
-                    )
-                )
-            )
-            return
-        }
-        
-        requestCertificateInner(playbackID: playbackID, drmConfig: config, completion: requestCompletion)
     }
 
-    func requestLicense(
-        spcData: Data,
-        playbackID: String,
-        offline: Bool,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
-        guard let config = onlineKeyConfigLookup[playbackID] else {
-            logger.debug(
-                "No registered DRM configuration for playbackID \(playbackID)."
-            )
-            requestCompletion(
-                .failure(
-                    FairPlaySessionError.unexpected(
-                        message: "No registered DRM configuration for playbackID \(playbackID)"
-                    )
-                )
-            )
-            return
+    // MARK: Requesting licenses and certs
+
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data {
+        guard let config = await drmConfigOnQueue(for: playbackID, offline: offline) else {
+            throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
         }
-        
-        requestLicenseInner(spcData: spcData, playbackID: playbackID, drmConfig: config, completion: requestCompletion)
+
+        return try await requestCertificateInner(playbackID: playbackID, drmConfig: config)
     }
-    
+
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data {
+        guard let config = await drmConfigOnQueue(for: playbackID, offline: offline) else {
+            throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
+        }
+
+        return try await requestLicenseInner(spcData: spcData, playbackID: playbackID, drmConfig: config)
+    }
+
     /// Requests the App Certificate for a playback id
     private func requestCertificateInner(
         playbackID: String,
-        drmConfig config: DRMConfig,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
+        drmConfig config: DRMConfig
+    ) async throws -> Data {
         let rootDomain = config.rootDomain
         let drmToken = config.options.drmToken
 
@@ -262,16 +180,11 @@ class DefaultFairPlayStreamingSessionManager<
             let error = FairPlaySessionError.unexpected(
                 message: "Invalid certificate domain"
             )
-            requestCompletion(
-                Result.failure(
-                    error
-                )
-            )
             errorDispatcher.dispatchApplicationCertificateRequestError(
                 error: error,
                 playbackID: playbackID
             )
-            return
+            throw error
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -280,102 +193,81 @@ class DefaultFairPlayStreamingSessionManager<
             "Requesting application certificate from \(url, privacy: .auto(mask: .hash))"
         )
 
-        let dataTask = urlSession.dataTask(with: request) { [requestCompletion] data, response, error in
-            self.logger.debug(
-                "Application certificate request completed"
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            logger.debug(
+                "Application certificate request failed with error: \(error.localizedDescription)"
             )
+            let fpsError = FairPlaySessionError.because(cause: error)
+            errorDispatcher.dispatchApplicationCertificateRequestError(
+                error: fpsError,
+                playbackID: playbackID
+            )
+            throw fpsError
+        }
 
-            var responseCode: Int? = nil
-            if let httpResponse = response as? HTTPURLResponse {
-                responseCode = httpResponse.statusCode
-                self.logger.debug(
-                    "Application certificate response code: \(httpResponse.statusCode)"
-                )
-                self.logger.debug(
-                    "Application certificate response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
-                )
-                if let data, let utfData = String(
-                    data: data,
-                    encoding: .utf8
-                ) {
-                    self.logger.debug(
-                        "Application certificate data: \(utfData)"
-                    )
-                }
+        logger.debug(
+            "Application certificate request completed"
+        )
 
-            }
-            // error case: I/O failed
-            if let error = error {
-                self.logger.debug(
-                    "Application certificate request failed with error: \(error.localizedDescription)"
+        if let httpResponse = response as? HTTPURLResponse {
+            logger.debug(
+                "Application certificate response code: \(httpResponse.statusCode)"
+            )
+            logger.debug(
+                "Application certificate response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
+            )
+            if let utfData = String(data: data, encoding: .utf8) {
+                logger.debug(
+                    "Application certificate data: \(utfData)"
                 )
-                let error = FairPlaySessionError.because(cause: error)
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchApplicationCertificateRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
             }
+
             // error case: I/O finished with non-successful response
-            guard responseCode == 200 else {
-                self.logger.debug(
-                    "Application certificate request failed with response code: \(String(describing: responseCode))"
+            guard httpResponse.statusCode == 200 else {
+                logger.debug(
+                    "Application certificate request failed with response code: \(httpResponse.statusCode)"
                 )
                 let error = FairPlaySessionError.httpFailed(
-                    responseStatusCode: responseCode ?? 0
+                    responseStatusCode: httpResponse.statusCode
                 )
-                requestCompletion(
-                    Result.failure(
-                        error
-                    )
-                )
-                self.errorDispatcher.dispatchApplicationCertificateRequestError(
+                errorDispatcher.dispatchApplicationCertificateRequestError(
                     error: error,
                     playbackID: playbackID
                 )
-                return
+                throw error
             }
-            // this edge case (200 with invalid data) is possible from our DRM vendor
-            guard let data = data,
-                  data.count > 0 else {
-                let error = FairPlaySessionError.unexpected(
-                    message: "No cert data with 200 OK response"
-                )
-                self.logger.debug(
-                    "Application certificate request completed with missing data and response code \(responseCode.debugDescription)"
-                )
-                requestCompletion(
-                    Result.failure(
-                        error
-                    )
-                )
-                self.errorDispatcher.dispatchApplicationCertificateRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
-            }
-            
-            self.logger.debug("Application certificate response data:\(data.base64EncodedString(), privacy: .auto(mask: .hash))")
-
-            requestCompletion(Result.success(data))
         }
-        
-        dataTask.resume()
+
+        // this edge case (200 with invalid data) is possible from our DRM vendor
+        guard data.count > 0 else {
+            let error = FairPlaySessionError.unexpected(
+                message: "No cert data with 200 OK response"
+            )
+            logger.debug(
+                "Application certificate request completed with missing data"
+            )
+            errorDispatcher.dispatchApplicationCertificateRequestError(
+                error: error,
+                playbackID: playbackID
+            )
+            throw error
+        }
+
+        logger.debug("Application certificate response data:\(data.base64EncodedString(), privacy: .auto(mask: .hash))")
+
+        return data
     }
-    
+
     /// Requests a license to play based on the given SPC data
-    /// - parameter offline - Not currently used, may not ever be used in short-term, maybe delete?
     private func requestLicenseInner(
         spcData: Data,
         playbackID: String,
-        drmConfig config: DRMConfig,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
-
+        drmConfig config: DRMConfig
+    ) async throws -> Data {
         let drmToken = config.options.drmToken
         let rootDomain = config.rootDomain
 
@@ -387,97 +279,75 @@ class DefaultFairPlayStreamingSessionManager<
             let error = FairPlaySessionError.unexpected(
                 message: "Invalid FairPlay license domain"
             )
-            requestCompletion(
-                Result.failure(
-                    error
-                )
-            )
             errorDispatcher.dispatchLicenseRequestError(
                 error: error,
                 playbackID: playbackID
             )
-            return
+            throw error
         }
 
         var request = URLRequest(url: url)
-        
-        // POST body is the SPC bytes
         request.httpMethod = "POST"
         request.httpBody = spcData
-        
-        // QUERY PARAMS
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         request.setValue(String(format: "%lu", request.httpBody?.count ?? 0), forHTTPHeaderField: "Content-Length")
         logger.debug("Sending License/CKC Request to: \(request.url?.absoluteString ?? "nil")")
         logger.debug("\t with header fields: \(String(describing: request.allHTTPHeaderFields))")
 
-        let task = urlSession.dataTask(with: request) { [requestCompletion] data, response, error in
-            // error case: I/O failed
-            if let error = error {
-                self.logger.debug(
-                    "URL Session Task Failed: \(error.localizedDescription)"
-                )
-                let error = FairPlaySessionError.because(cause: error)
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchLicenseRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
-            }
-            
-            var responseCode: Int? = nil
-            if let httpResponse = response as? HTTPURLResponse {
-                responseCode = httpResponse.statusCode
-                self.logger.debug(
-                    "License response code: \(httpResponse.statusCode)"
-                )
-                self.logger.debug(
-                    "License response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
-                )
-            }
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            logger.debug(
+                "URL Session Task Failed: \(error.localizedDescription)"
+            )
+            let fpsError = FairPlaySessionError.because(cause: error)
+            errorDispatcher.dispatchLicenseRequestError(
+                error: fpsError,
+                playbackID: playbackID
+            )
+            throw fpsError
+        }
+
+        if let httpResponse = response as? HTTPURLResponse {
+            logger.debug(
+                "License response code: \(httpResponse.statusCode)"
+            )
+            logger.debug(
+                "License response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
+            )
+
             // error case: I/O finished with non-successful response
-            guard responseCode == 200 else {
-                self.logger.debug(
-                    "CKC request failed: \(String(describing: responseCode))"
+            guard httpResponse.statusCode == 200 else {
+                logger.debug(
+                    "CKC request failed: \(httpResponse.statusCode)"
                 )
                 let error = FairPlaySessionError.httpFailed(
-                    responseStatusCode: responseCode ?? 0
+                    responseStatusCode: httpResponse.statusCode
                 )
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchLicenseRequestError(
+                errorDispatcher.dispatchLicenseRequestError(
                     error: error,
                     playbackID: playbackID
                 )
-
-                return
+                throw error
             }
-            // strange edge case: 200 with no response body
-            //  this happened because of a client-side encoding difference causing an error
-            //  with our drm vendor and probably shouldn't be reachable, but lets not crash
-            guard let data = data,
-                  data.count > 0
-            else {
-                let error = FairPlaySessionError.unexpected(message: "No license data with 200 response")
-                self.logger.debug("No CKC data despite server returning success")
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchLicenseRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
-            }
-            
-            let ckcData = data
-            requestCompletion(Result.success(ckcData))
         }
-        task.resume()
+
+        // strange edge case: 200 with no response body
+        //  this happened because of a client-side encoding difference causing an error
+        //  with our drm vendor and probably shouldn't be reachable, but lets not crash
+        guard data.count > 0 else {
+            let error = FairPlaySessionError.unexpected(message: "No license data with 200 response")
+            logger.debug("No CKC data despite server returning success")
+            errorDispatcher.dispatchLicenseRequestError(
+                error: error,
+                playbackID: playbackID
+            )
+            throw error
+        }
+
+        return data
     }
     
     // MARK: registering assets
@@ -539,9 +409,18 @@ class DefaultFairPlayStreamingSessionManager<
         self.contentKeySession.addContentKeyRecipient(urlAsset)
     }
     
-    func hasOfflineDRMConfig(playbackID: String) -> Bool {
-        // called from ContentKeySessionDelegate, is definitely on .queue
-        return offlinePlayLookup[playbackID] != nil || offlineDownloadKeyLookup[playbackID] != nil
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            queue.async { [logger, weak self] in
+                guard let self else {
+                    logger.warning("looked up offline DRM config after cleanup")
+                    continuation.resume(returning: false)
+                    return
+                }
+                let result = offlinePlayLookup[playbackID] != nil || offlineDownloadKeyLookup[playbackID] != nil
+                continuation.resume(returning: result)
+            }
+        }
     }
     
     func offlineKeyData(playbackID: String) -> Data? {

--- a/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
@@ -9,13 +9,7 @@ import os
 
 // internal class to manage dependency injection
 class PlayerSDK {
-    #if DEBUG
-    // TODO: This @TaskLocal is making lots of things hard. Figure that out
-    //    @TaskLocal
     static var shared = PlayerSDK()
-    #else
-    static let shared = PlayerSDK()
-    #endif
 
     var monitor: Monitor
 

--- a/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
@@ -9,7 +9,11 @@ import os
 
 // internal class to manage dependency injection
 class PlayerSDK {
+    #if DEBUG
     static var shared = PlayerSDK()
+    #else
+    static let shared = PlayerSDK()
+    #endif
 
     var monitor: Monitor
 

--- a/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
@@ -10,7 +10,8 @@ import os
 // internal class to manage dependency injection
 class PlayerSDK {
     #if DEBUG
-    @TaskLocal
+    // TODO: This @TaskLocal is making lots of things hard. Figure that out
+    //    @TaskLocal
     static var shared = PlayerSDK()
     #else
     static let shared = PlayerSDK()
@@ -91,6 +92,7 @@ class PlayerSDK {
                 category: "External"
             )
         )
+        
         self.reverseProxyServer = ReverseProxyServer()
     }
 
@@ -140,6 +142,22 @@ class PlayerSDK {
                 playbackID: playbackID,
                 options: drmOptions,
                 rootDomain: playbackOptions.rootDomain())
+        }
+    }
+    
+    func registerOfflineDRMAsset(
+        _ urlAsset: AVURLAsset,
+        playbackID: String,
+        playbackOptions: PlaybackOptions
+    ) {
+        // as? AVURLAsset check should never fail
+        if case .drm(let drmOptions) = playbackOptions.playbackPolicy {
+            fairPlaySessionManager.addOfflineDownloadDRMAsset(
+                urlAsset,
+                playbackID: playbackID,
+                options: drmOptions,
+                rootDomain: playbackOptions.rootDomain()
+            )
         }
     }
 

--- a/Sources/MuxPlayerSwift/Offline/DRMTokenClaims.swift
+++ b/Sources/MuxPlayerSwift/Offline/DRMTokenClaims.swift
@@ -1,0 +1,45 @@
+//
+//  DRMTokenClaims.swift
+//  MuxPlayerSwift
+//
+
+import Foundation
+
+struct DRMTokenClaims {
+    /// Seconds from license creation until expiration (when not yet played)
+    let licenseExpiration: TimeInterval?
+    /// Seconds from first playback until expiration
+    let playDuration: TimeInterval?
+    /// Whether the token is for offline use
+    let offline: Bool
+
+    /// Parses claims from a JWT's payload segment (no signature verification).
+    static func from(drmToken: String) -> DRMTokenClaims? {
+        let segments = drmToken.split(separator: ".")
+        guard segments.count == 3 else { return nil }
+
+        var base64 = String(segments[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        // Pad to multiple of 4
+        while base64.count % 4 != 0 {
+            base64.append("=")
+        }
+
+        guard let data = Data(base64Encoded: base64) else { return nil }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        let licenseExpiration = json["licenseExpiration"] as? TimeInterval
+        let playDuration = json["playDuration"] as? TimeInterval
+        let offline = json["offline"] as? Bool ?? false
+
+        return DRMTokenClaims(
+            licenseExpiration: licenseExpiration,
+            playDuration: playDuration,
+            offline: offline
+        )
+    }
+}

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -115,8 +115,8 @@ actor DownloadIndex {
             redownloadExpiration: existing.redownloadExpiration,
             expireLicenseFrom: existing.expireLicenseFrom,
             expirationPhase: existing.expirationPhase,
-            licenseExpirationDuration: existing.licenseExpirationDuration,
-            playDurationDuration: existing.playDurationDuration
+            licenseExpirationSeconds: existing.licenseExpirationSeconds,
+            playDurationSeconds: existing.playDurationSeconds
         )
         assets[playbackID] = updated
         persist()
@@ -144,8 +144,8 @@ actor DownloadIndex {
             redownloadExpiration: existing.redownloadExpiration,
             expireLicenseFrom: existing.expireLicenseFrom,
             expirationPhase: existing.expirationPhase,
-            licenseExpirationDuration: existing.licenseExpirationDuration,
-            playDurationDuration: existing.playDurationDuration
+            licenseExpirationSeconds: existing.licenseExpirationSeconds,
+            playDurationSeconds: existing.playDurationSeconds
         )
         assets[playbackID] = updated
         persist()
@@ -173,8 +173,8 @@ actor DownloadIndex {
             redownloadExpiration: existing.redownloadExpiration,
             expireLicenseFrom: existing.expireLicenseFrom,
             expirationPhase: existing.expirationPhase,
-            licenseExpirationDuration: existing.licenseExpirationDuration,
-            playDurationDuration: existing.playDurationDuration
+            licenseExpirationSeconds: existing.licenseExpirationSeconds,
+            playDurationSeconds: existing.playDurationSeconds
         )
         assets[playbackID] = updated
         persist()
@@ -200,8 +200,8 @@ actor DownloadIndex {
             redownloadExpiration: existing.redownloadExpiration,
             expireLicenseFrom: Date(),
             expirationPhase: phase,
-            licenseExpirationDuration: existing.licenseExpirationDuration,
-            playDurationDuration: existing.playDurationDuration
+            licenseExpirationSeconds: existing.licenseExpirationSeconds,
+            playDurationSeconds: existing.playDurationSeconds
         )
         assets[playbackID] = updated
         persist()

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -75,7 +75,7 @@ actor DownloadIndex {
             // Delete CKC sidecar if any
             if let ckcFilePath = stored.ckcFilePath {
                 do {
-                    let ckcDir = try Self.persistenKeyDirectory()
+                    let ckcDir = try Self.persistentKeyDirectory()
                     let ckcFile = URL(fileURLWithPath: ckcFilePath, relativeTo: ckcDir)
                     try fm.removeItem(at: ckcFile)
                 } catch {
@@ -201,7 +201,7 @@ actor DownloadIndex {
         return updated
     }
     
-    public static func persistenKeyDirectory() throws -> URL {
+    public static func persistentKeyDirectory() throws -> URL {
         let baseURL = try FileManager.default.url(
             for: .libraryDirectory,
             in: .userDomainMask,

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -25,15 +25,18 @@ actor DownloadIndex {
         let assets: [String: StoredAsset]
     }
 
-    private var assets: [String: StoredAsset] = [:]
+    private var assets: [String: StoredAsset]
 
     init() {
         do {
-            if let snapshot = try loadSnapshot() {
+            if let snapshot = try Self.loadSnapshot() {
                 assets = snapshot.assets
+            } else {
+                assets = [:]
             }
         } catch {
             logger.error("[Mux-Offline] DownloadIndex init load error: \(error.localizedDescription)")
+            assets = [:]
         }
     }
 
@@ -226,7 +229,7 @@ actor DownloadIndex {
         }
     }
 
-    private func indexDirectoryURL() throws -> URL {
+    private static func indexDirectoryURL() throws -> URL {
         let fm = FileManager.default
         let base = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         let dir = base.appendingPathComponent("com.mux.offline", isDirectory: true)
@@ -238,13 +241,12 @@ actor DownloadIndex {
         do {
             try mutableDir.setResourceValues(values)
         } catch {
-            // not generally an error condition. if the index is restored, callers will see .mustRedownload for all entries. not the end of the world
-            logger.warning("[Mux-Offline] failed to exclude \(mutableDir) from backup. continuing anyway")
+            PlayerSDK.shared.diagnosticsLogger.trace("Couldn't exclude index from backup: \(error)")
         }
         return dir
     }
 
-    private func indexFileURL() throws -> URL {
+    private static func indexFileURL() throws -> URL {
         try indexDirectoryURL().appendingPathComponent("index.plist", isDirectory: false)
     }
 
@@ -253,7 +255,7 @@ actor DownloadIndex {
         encoder.outputFormat = .binary
         let data = try encoder.encode(snapshot)
 
-        let url = try indexFileURL()
+        let url = try Self.indexFileURL()
         let tmp = url.deletingLastPathComponent().appendingPathComponent(UUID().uuidString)
         try data.write(to: tmp, options: .atomic)
         do {
@@ -263,7 +265,7 @@ actor DownloadIndex {
         }
     }
 
-    private func loadSnapshot() throws -> IndexSnapshot? {
+    private static func loadSnapshot() throws -> IndexSnapshot? {
         let url = try indexFileURL()
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         let data = try Data(contentsOf: url)

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -92,6 +92,7 @@ actor DownloadIndex {
 
     // MARK: - Partial Updates
 
+    @discardableResult
     func updateIsComplete(playbackID: String, isComplete: Bool, completeWithError: Bool) -> StoredAsset? {
         // not an error case. Deletion can occur re-entrantly before the delegate callback that calls this
         guard let existing = assets[playbackID] else {
@@ -120,6 +121,7 @@ actor DownloadIndex {
         return updated
     }
 
+    @discardableResult
     func updateCKCFileURL(playbackID: String, ckcFilePath: String?) -> StoredAsset? {
         // not an error case. Deletion can occur re-entrantly before the delegate callback that calls this
         guard let existing = assets[playbackID] else {
@@ -148,6 +150,7 @@ actor DownloadIndex {
         return updated
     }
 
+    @discardableResult
     func updateLocalPathURL(playbackID: String, localPath: String) -> StoredAsset? {
         // not an error case. Deletion can occur re-entrantly before the delegate callback that calls this
         guard let existing = assets[playbackID] else {
@@ -175,6 +178,7 @@ actor DownloadIndex {
         return updated
     }
 
+    @discardableResult
     func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) -> StoredAsset? {
         guard let existing = assets[playbackID] else {
             logger.warning("[Mux-Offline] DownloadIndex.updateExpirationPhase: No existing asset for playbackID \(playbackID)")

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -74,12 +74,13 @@ actor DownloadIndex {
             
             // Delete CKC sidecar if any
             if let ckcFilePath = stored.ckcFilePath {
-                let ckcFile = URL(fileURLWithPath: ckcFilePath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
                 do {
+                    let ckcDir = try Self.persistenKeyDirectory()
+                    let ckcFile = URL(fileURLWithPath: ckcFilePath, relativeTo: ckcDir)
                     try fm.removeItem(at: ckcFile)
                 } catch {
                     // not generally an error condition. file can be gone due to early cancellation or re-entrant calls to this method
-                    logger.trace("[Mux-Offline] Failed to key id file at \(ckcFile.path): \(error)")
+                    logger.trace("[Mux-Offline] Failed to key id file at \(ckcFilePath): \(error)")
                 }
             }
         }
@@ -107,16 +108,19 @@ actor DownloadIndex {
             subtitleLanguages: existing.subtitleLanguages,
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: existing.ckcFilePath,
-            keyExpiration: existing.keyExpiration,
-            redownloadExpiration: existing.redownloadExpiration
+            redownloadExpiration: existing.redownloadExpiration,
+            downloadedAt: existing.downloadedAt,
+            expirationPhase: existing.expirationPhase,
+            licenseExpirationDuration: existing.licenseExpirationDuration,
+            playDurationDuration: existing.playDurationDuration
         )
         assets[playbackID] = updated
         persist()
-        
+
         return updated
     }
 
-    func updateCKCFileURL(playbackID: String, ckcFilePath: String) -> StoredAsset? {
+    func updateCKCFileURL(playbackID: String, ckcFilePath: String?) -> StoredAsset? {
         // not an error case. Deletion can occur re-entrantly before the delegate callback that calls this
         guard let existing = assets[playbackID] else {
             logger.warning("[Mux-Offline] DownloadIndex.updateCKCFileURL: No existing asset for playbackID \(playbackID)")
@@ -132,12 +136,15 @@ actor DownloadIndex {
             subtitleLanguages: existing.subtitleLanguages,
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: ckcFilePath,
-            keyExpiration: existing.keyExpiration,
-            redownloadExpiration: existing.redownloadExpiration
+            redownloadExpiration: existing.redownloadExpiration,
+            downloadedAt: existing.downloadedAt,
+            expirationPhase: existing.expirationPhase,
+            licenseExpirationDuration: existing.licenseExpirationDuration,
+            playDurationDuration: existing.playDurationDuration
         )
         assets[playbackID] = updated
         persist()
-        
+
         return updated
     }
 
@@ -157,14 +164,54 @@ actor DownloadIndex {
             subtitleLanguages: existing.subtitleLanguages,
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: existing.ckcFilePath,
-            keyExpiration: existing.keyExpiration,
-            redownloadExpiration: existing.redownloadExpiration
+            redownloadExpiration: existing.redownloadExpiration,
+            downloadedAt: existing.downloadedAt,
+            expirationPhase: existing.expirationPhase,
+            licenseExpirationDuration: existing.licenseExpirationDuration,
+            playDurationDuration: existing.playDurationDuration
         )
         assets[playbackID] = updated
         persist()
         return updated
     }
 
+    func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) -> StoredAsset? {
+        guard let existing = assets[playbackID] else {
+            logger.warning("[Mux-Offline] DownloadIndex.updateExpirationPhase: No existing asset for playbackID \(playbackID)")
+            return nil
+        }
+        let updated = StoredAsset(
+            isComplete: existing.isComplete,
+            completedWithError: existing.completedWithError,
+            playbackID: existing.playbackID,
+            localPath: existing.localPath,
+            readableTitle: existing.readableTitle,
+            posterDataBase64: existing.posterDataBase64,
+            subtitleLanguages: existing.subtitleLanguages,
+            secondaryAudioLanguages: existing.secondaryAudioLanguages,
+            ckcFilePath: existing.ckcFilePath,
+            redownloadExpiration: existing.redownloadExpiration,
+            downloadedAt: existing.downloadedAt,
+            expirationPhase: phase,
+            licenseExpirationDuration: existing.licenseExpirationDuration,
+            playDurationDuration: existing.playDurationDuration
+        )
+        assets[playbackID] = updated
+        persist()
+        return updated
+    }
+    
+    public static func persistenKeyDirectory() throws -> URL {
+        let baseURL = try FileManager.default.url(
+            for: .libraryDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        return URL(fileURLWithPath: "mux-offline", relativeTo: baseURL)
+    }
+
+    
     // MARK: - Persistence
 
     private func persist() {

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -109,7 +109,7 @@ actor DownloadIndex {
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: existing.ckcFilePath,
             redownloadExpiration: existing.redownloadExpiration,
-            downloadedAt: existing.downloadedAt,
+            expireLicenseFrom: existing.expireLicenseFrom,
             expirationPhase: existing.expirationPhase,
             licenseExpirationDuration: existing.licenseExpirationDuration,
             playDurationDuration: existing.playDurationDuration
@@ -137,7 +137,7 @@ actor DownloadIndex {
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: ckcFilePath,
             redownloadExpiration: existing.redownloadExpiration,
-            downloadedAt: existing.downloadedAt,
+            expireLicenseFrom: existing.expireLicenseFrom,
             expirationPhase: existing.expirationPhase,
             licenseExpirationDuration: existing.licenseExpirationDuration,
             playDurationDuration: existing.playDurationDuration
@@ -165,7 +165,7 @@ actor DownloadIndex {
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: existing.ckcFilePath,
             redownloadExpiration: existing.redownloadExpiration,
-            downloadedAt: existing.downloadedAt,
+            expireLicenseFrom: existing.expireLicenseFrom,
             expirationPhase: existing.expirationPhase,
             licenseExpirationDuration: existing.licenseExpirationDuration,
             playDurationDuration: existing.playDurationDuration
@@ -191,7 +191,7 @@ actor DownloadIndex {
             secondaryAudioLanguages: existing.secondaryAudioLanguages,
             ckcFilePath: existing.ckcFilePath,
             redownloadExpiration: existing.redownloadExpiration,
-            downloadedAt: existing.downloadedAt,
+            expireLicenseFrom: Date(),
             expirationPhase: phase,
             licenseExpirationDuration: existing.licenseExpirationDuration,
             playDurationDuration: existing.playDurationDuration

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -204,6 +204,11 @@ actor DownloadManager: PersistedKeyStore {
     }
     
     func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async {
+        let existingRecord = await index.get(playbackID: playbackID)
+        if case .playDuration = phase, case .playDuration = existingRecord?.expirationPhase {
+            logger.trace("Already in playDuration phase. Not updating again.")
+            return
+        }
         await index.updateExpirationPhase(playbackID: playbackID, phase: phase)
     }
 

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -167,26 +167,17 @@ actor DownloadManager {
         
         let ckcFileDir = try DownloadIndex.persistenKeyDirectory()
         let fileURL = URL(fileURLWithPath: localFile, relativeTo: ckcFileDir)
-//        logger.info("Looking for CKC to file at: \(fileURL.path)")
-//        logger.info("Looking for CKC to file at (relative): \(fileURL.relativePath)")
-//        logger.info("Looking for CKC to file at (relative): \(fileURL)")
         guard assetFileExists(at: fileURL) else {
             logger.warning("CKC file doesn't exist for \(playbackID) at \(fileURL.absoluteString)")
             return nil
         }
-//        logger.trace("CKC file found for \(playbackID) at \(fileURL.absoluteString)")
-        // returns nil if there's a read error
         return FileManager.default.contents(atPath: fileURL.path)
     }
     
     /// Starts a new Download Task. If there was already a task in progress for this playbackID,
     func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws {
-        // TODO: Save that dude to a file
-        //        try await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: ckcFileURL.relativePath)
-        
         guard let asset = await index.get(playbackID: playbackID) else {
-            logger.warning("[Mux-Offline] tried to save persistent key for not-index playbackID: \(playbackID)")
-            // TODO: Should we throw?
+            logger.warning("[Mux-Offline] tried to save persistent key for non-indexed playbackID: \(playbackID)")
             return
         }
         
@@ -201,8 +192,6 @@ actor DownloadManager {
         }
         
         let newCkcFileURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
-        //        logger.info("Saved CKC to file at: \(newCkcFileURL.path)")
-        //        logger.info("Saved CKC to file at (relative): \(newCkcFileURL)")
         logger.info("Saving CKC to file at (relative): \(newCkcFileURL.relativePath)")
         
         // update index first. Better to have blank entries here than orphaned files on disk
@@ -301,19 +290,21 @@ actor DownloadManager {
     }
     
     private func addDRMInfoTo(_ urlAsset: AVURLAsset, playbackID: String) async {
-        // TODO: try?
-        let persistedContentKey = await try? findPeristedContentKey(playbackID: playbackID)
+        let persistedContentKey: Data?
+        do {
+            persistedContentKey = await try findPeristedContentKey(playbackID: playbackID)
+        } catch {
+            logger.warning("Couldn't find persisted content key for \(playbackID): \(error)")
+            return
+        }
         // We are only sending to the main actor so we know this will be safe
         if let persistedContentKey {
             // We only need MainActor because PlayerSDK.shared is TaskLocal on debug
-            //                await MainActor.run {
-            // TODO: Can just store the key Data here
             await PlayerSDK.shared.fairPlaySessionManager.addOfflinePlayDRMAsset(
                 urlAsset,
                 playbackID: playbackID,
                 keyData: persistedContentKey
             )
-            //                }
         }
     }
     

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -55,33 +55,12 @@ actor DownloadManager: PersistedKeyStore {
             logger.warning("[Mux-Offline] findDownloadedAsset: No local path saved for completed asset")
             return nil
         }
-
-        if storedAsset.isExpired() {
-            return DownloadedAsset(
-                playbackID: playbackID,
-                assetStatus: .expired,
-                downloadOptions: DownloadOptions(from: storedAsset)
-            )
-        }
-
-        let fileURL = URL(fileURLWithPath: file, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
-        if assetFileExists(at: fileURL), !storedAsset.completedWithError {
-            let urlAsset = AVURLAsset(url: fileURL)
-            if storedAsset.ckcFilePath != nil {
-                await addDRMInfoTo(urlAsset, playbackID: playbackID)
-            }
-            
-            return DownloadedAsset(
-                playbackID: playbackID,
-                assetStatus: .playable(asset: urlAsset),
-                downloadOptions: DownloadOptions(from: storedAsset)
-            )
-        } else {
-            return DownloadedAsset(
-                playbackID: playbackID,
-                assetStatus: .redownloadWhenOnline,
-                downloadOptions: DownloadOptions(from: storedAsset)
-            )
+        
+        do {
+            return try await makeDownloadedAsset(from: storedAsset)
+        } catch {
+            logger.error("Unexpected failure to make downloaded asset: \(error)")
+            return nil
         }
     }
     
@@ -162,7 +141,7 @@ actor DownloadManager: PersistedKeyStore {
         
         let ckcFileDir = try DownloadIndex.persistentKeyDirectory()
         let fileURL = URL(fileURLWithPath: localFile, relativeTo: ckcFileDir)
-        guard assetFileExists(at: fileURL) else {
+        guard fileExists(at: fileURL) else {
             logger.warning("CKC file doesn't exist for \(playbackID) at \(fileURL.absoluteString)")
             return nil
         }
@@ -213,44 +192,21 @@ actor DownloadManager: PersistedKeyStore {
     }
 
     func allCompletedAssets() async -> [DownloadedAsset] {
-        let completedAssets = await index.all()
-            .filter { $0.isComplete }
-            .compactMap { completedAsset -> DownloadedAsset? in
-                guard let assetPath = completedAsset.localPath else {
-                    logger.warning("[Mux-Offline] allCompletedAssets: No local path saved for completed asset")
-                    return nil
-                }
-                let assetURL = URL(fileURLWithPath: assetPath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
-                let urlAsset = AVURLAsset(url: assetURL)
-
-                if completedAsset.isExpired() {
-                    return DownloadedAsset(
-                        playbackID: completedAsset.playbackID,
-                        assetStatus: .expired,
-                        downloadOptions: DownloadOptions(from: completedAsset)
-                    )
-                } else if assetFileExists(at: assetURL), !completedAsset.completedWithError {
-                    return DownloadedAsset(
-                        playbackID: completedAsset.playbackID,
-                        assetStatus: .playable(asset: urlAsset),
-                        downloadOptions: DownloadOptions(from: completedAsset)
-                    )
-                } else {
-                    return DownloadedAsset(
-                        playbackID: completedAsset.playbackID,
-                        assetStatus: .redownloadWhenOnline,
-                        downloadOptions: DownloadOptions(from: completedAsset)
-                    )
-                }
-            }
+        let completedAssets = await index.all().filter { $0.isComplete }
         
-        for asset in completedAssets {
-            if let urlAsset = asset.avAssetIfPlayable() {
-                await addDRMInfoTo(urlAsset, playbackID: asset.playbackID)
+        var downloadedAssets: [DownloadedAsset] = []
+        for completedAsset in completedAssets {
+            do {
+                let downloadedAsset = try await makeDownloadedAsset(from: completedAsset)
+                if let downloadedAsset {
+                    downloadedAssets.append(downloadedAsset)
+                }
+            } catch {
+                logger.error("Unexpexted failure to create DownloadedAsset: \(error.localizedDescription)")
             }
         }
         
-        return completedAssets
+        return downloadedAssets
     }
     
     func allInProgressTasks() async -> [String: AnyPublisher<DownloadEvent, Error>] {
@@ -288,6 +244,63 @@ actor DownloadManager: PersistedKeyStore {
         return subject.eraseToAnyPublisher()
     }
     
+    private func makeDownloadedAsset(from completedAsset: StoredAsset) async throws -> DownloadedAsset? {
+        guard let assetPath = completedAsset.localPath else {
+            logger.warning("[Mux-Offline] allCompletedAssets: No local path saved for completed asset")
+            return nil
+        }
+        let assetURL = URL(fileURLWithPath: assetPath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
+        let urlAsset = AVURLAsset(url: assetURL)
+        let expectsDRM = completedAsset.ckcFilePath != nil
+        // Error here means no Library directory, which is an error
+        let contentKey = try await findPersistedContentKey(playbackID: completedAsset.playbackID)
+
+        // DRM cases
+        if expectsDRM {
+            if completedAsset.isExpired() {
+                // license expiration
+                return DownloadedAsset(
+                    playbackID: completedAsset.playbackID,
+                    assetStatus: .expired,
+                    downloadOptions: DownloadOptions(from: completedAsset)
+                )
+            }
+            
+            guard let contentKey else {
+                // DRM asset but content key corrupt or something. Return .redownloadWhenOnline
+                //  (not a common case)
+                logger.warning("Content Key unexpectedly can't be opened for \(completedAsset.playbackID)")
+                return DownloadedAsset(
+                    playbackID: completedAsset.playbackID,
+                    assetStatus: .redownloadWhenOnline,
+                    downloadOptions: DownloadOptions(from: completedAsset)
+                )
+            }
+            
+            logger.trace("Persisted content key OK.")
+            await PlayerSDK.shared.fairPlaySessionManager.addOfflinePlayDRMAsset(
+                urlAsset,
+                playbackID: completedAsset.playbackID,
+                keyData: contentKey
+            )
+        }
+        
+        logger.trace("Checking for asset file")
+        if fileExists(at: assetURL), !completedAsset.completedWithError {
+            return DownloadedAsset(
+                playbackID: completedAsset.playbackID,
+                assetStatus: .playable(asset: urlAsset),
+                downloadOptions: DownloadOptions(from: completedAsset)
+            )
+        } else {
+            return DownloadedAsset(
+                playbackID: completedAsset.playbackID,
+                assetStatus: .redownloadWhenOnline,
+                downloadOptions: DownloadOptions(from: completedAsset)
+            )
+        }
+    }
+    
     private func addDRMInfoTo(_ urlAsset: AVURLAsset, playbackID: String) async {
         let persistedContentKey: Data?
         do {
@@ -321,9 +334,8 @@ actor DownloadManager: PersistedKeyStore {
         return URL(fileURLWithPath: fileName, relativeTo: directoryURL)
     }
     
-    
-    private func assetFileExists(at movPkgURL: URL) -> Bool {
-        return FileManager.default.fileExists(atPath: movPkgURL.path)
+    private func fileExists(at fileURL: URL) -> Bool {
+        return FileManager.default.fileExists(atPath: fileURL.path)
     }
     
     private func tasksFromSession() async -> [URLSessionTask] {

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -128,11 +128,7 @@ actor DownloadManager {
         
         // Adds the asset as a ContentKeyRecipient, if it's DRM-protected
         if case .drm(let drmOptions) = playbackOptions.playbackPolicy {
-            // this has to run on the main thread (on debug builds) because PlayerSDK.shared is TaskLocal and will crash if created in a BG thread
-            //  (begging the question, does making PlayerSDK.shared task-local have any real impact?)
-            await MainActor.run {
-                PlayerSDK.shared.registerOfflineDRMAsset(avAsset, playbackID: playbackID, playbackOptions: playbackOptions)
-            }
+            PlayerSDK.shared.registerOfflineDRMAsset(avAsset, playbackID: playbackID, playbackOptions: playbackOptions)
         }
         
         // start the task now that we're set up
@@ -146,9 +142,7 @@ actor DownloadManager {
         
         if let task = downloadTasksByPlaybackID[playbackID] {
             task.cancel()
-            await MainActor.run {
-                PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
-            }
+            PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
             
             downloadTasksByPlaybackID[playbackID] = nil
             // will also clear the subject, to avoid saving stale state
@@ -181,6 +175,11 @@ actor DownloadManager {
             return
         }
         
+        try FileManager.default.createDirectory(
+            at: DownloadIndex.persistenKeyDirectory(),
+            withIntermediateDirectories: true
+        )
+
         // Clean up old file if it exists
         if let existingFile = asset.ckcFilePath {
             let existingURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
@@ -190,11 +189,6 @@ actor DownloadManager {
                 logger.trace("Failed to delete existing CKC file (probably didn't exist): \(error)")
             }
         }
-        
-        try FileManager.default.createDirectory(
-            at: DownloadIndex.persistenKeyDirectory(),
-            withIntermediateDirectories: true
-        )
         
         let newCkcFileURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
         logger.info("Saving CKC to file at: \(newCkcFileURL.relativePath)")
@@ -300,7 +294,6 @@ actor DownloadManager {
         }
         // We are only sending to the main actor so we know this will be safe
         if let persistedContentKey {
-            // We only need MainActor because PlayerSDK.shared is TaskLocal on debug
             await PlayerSDK.shared.fairPlaySessionManager.addOfflinePlayDRMAsset(
                 urlAsset,
                 playbackID: playbackID,
@@ -423,9 +416,7 @@ actor DownloadManager {
         await index.updateIsComplete(playbackID: playbackID, isComplete: true, completeWithError: true)
         // Once a task errors, we can't resume where we left off, so just delete any partially-downloaded data
         await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: false)
-        await MainActor.run {
-            PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
-        }
+        PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
         
         // do these after the awaits, so callers that call startDownload to handle errors actually start one
         sendError(error, for: playbackID)
@@ -456,9 +447,7 @@ actor DownloadManager {
             return
         }
         
-        await MainActor.run {
-            PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
-        }
+        PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
 
         // Ensure localPath is set even if willDownloadTo's Task hasn't
         // run yet (actor task scheduling is not FIFO)

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -229,9 +229,7 @@ actor DownloadManager: PersistedKeyStore {
                         assetStatus: .expired,
                         downloadOptions: DownloadOptions(from: completedAsset)
                     )
-                }
-
-                if assetFileExists(at: assetURL), !completedAsset.completedWithError {
+                } else if assetFileExists(at: assetURL), !completedAsset.completedWithError {
                     return DownloadedAsset(
                         playbackID: completedAsset.playbackID,
                         assetStatus: .playable(asset: urlAsset),

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -31,11 +31,11 @@ actor DownloadManager {
         delegateQueue: delegateQueue
     )
     
-    #if DEBUG
+#if DEBUG
     private let logger = Logger(OSLog(subsystem: "com.mux.player", category: "Mux-Offline"))
-    #else 
+#else
     private let logger = Logger(.disabled)
-    #endif
+#endif
     
     private var reattachedTasks: Bool = false
     private let index = DownloadIndex()
@@ -55,13 +55,25 @@ actor DownloadManager {
             logger.warning("[Mux-Offline] findDownloadedAsset: No local path saved for completed asset")
             return nil
         }
-        // TODO: Check DRM expiration
-        
-        let fileURL = URL(fileURLWithPath: file, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
-        if assetFileExists(at: fileURL), !storedAsset.completedWithError {
+
+        if storedAsset.isExpired() {
             return DownloadedAsset(
                 playbackID: playbackID,
-                assetStatus: .playable(asset: AVURLAsset(url: fileURL)),
+                assetStatus: .expired,
+                downloadOptions: DownloadOptions(from: storedAsset)
+            )
+        }
+
+        let fileURL = URL(fileURLWithPath: file, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
+        if assetFileExists(at: fileURL), !storedAsset.completedWithError {
+            let urlAsset = AVURLAsset(url: fileURL)
+            if storedAsset.ckcFilePath != nil {
+                await addDRMInfoTo(urlAsset, playbackID: playbackID)
+            }
+            
+            return DownloadedAsset(
+                playbackID: playbackID,
+                assetStatus: .playable(asset: urlAsset),
                 downloadOptions: DownloadOptions(from: storedAsset)
             )
         } else {
@@ -73,13 +85,15 @@ actor DownloadManager {
         }
     }
     
-    /// Starts a new Download Task. If there was already a task in progress for this playbackID,
     /// tracks that task's progress instead of starting a new one.
     func startDownloadWithPublisher(
         playbackID: String,
         avAsset: AVURLAsset,
-        options: DownloadOptions
+        downloadOptions: DownloadOptions,
+        playbackOptions: PlaybackOptions
     ) async -> AnyPublisher<DownloadEvent, Error> {
+        print("--- URL I'm Downloading: \(avAsset.url)")
+        
         // If we already have a completed asset, return it. Caller can use it, or if it's not playable, they can explicitly delete
         let alreadyCompletedAsset = await findDownloadedAsset(playbackID: playbackID)
         if let alreadyCompletedAsset {
@@ -95,7 +109,7 @@ actor DownloadManager {
         
         // configure the new task, and keep track of it
         let subject = subject(for: playbackID)
-        let config = AVAssetDownloadConfiguration(asset: avAsset, title: options.readableTitle)
+        let config = AVAssetDownloadConfiguration(asset: avAsset, title: downloadOptions.readableTitle)
         let task = downloadSession.makeAssetDownloadTask(downloadConfiguration: config)
         task.taskDescription = playbackID
         // do this before we await the index management, so re-entrant calls don't orphan the task
@@ -104,11 +118,26 @@ actor DownloadManager {
         // clean up any old files that might exist (due to failed tasks, etc) before starting
         await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: true)
         // store DownloadOptions, etc in the index before we start
-        await index.upsert(StoredAsset.forNewDownload(playbackID: playbackID, options: options))
-
+        let drmClaims: DRMTokenClaims? = {
+            if case .drm(let drmOptions) = playbackOptions.playbackPolicy {
+                return DRMTokenClaims.from(drmToken: drmOptions.drmToken)
+            }
+            return nil
+        }()
+        await index.upsert(StoredAsset.forNewDownload(playbackID: playbackID, options: downloadOptions, drmClaims: drmClaims))
+        
+        // Adds the asset as a ContentKeyRecipient, if it's DRM-protected
+        if case .drm(let drmOptions) = playbackOptions.playbackPolicy {
+            // this has to run on the main thread (on debug builds) because PlayerSDK.shared is TaskLocal and will crash if created in a BG thread
+            //  (begging the question, does making PlayerSDK.shared task-local have any real impact?)
+            await MainActor.run {
+                PlayerSDK.shared.registerOfflineDRMAsset(avAsset, playbackID: playbackID, playbackOptions: playbackOptions)
+            }
+        }
+        
         // start the task now that we're set up
         task.resume()
-
+        
         return subject.eraseToAnyPublisher()
     }
     
@@ -117,6 +146,10 @@ actor DownloadManager {
         
         if let task = downloadTasksByPlaybackID[playbackID] {
             task.cancel()
+            await MainActor.run {
+                PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
+            }
+            
             downloadTasksByPlaybackID[playbackID] = nil
             // will also clear the subject, to avoid saving stale state
             sendError(URLError(.cancelled), for: playbackID)
@@ -124,8 +157,73 @@ actor DownloadManager {
         await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: true)
     }
     
+    /// If an asset is stored in the index (completed or not), and it has a persisted content key, returns it
+    func findPeristedContentKey(playbackID: String) async throws -> Data? {
+        guard let storedAsset = await index.get(playbackID: playbackID),
+              let localFile = storedAsset.ckcFilePath
+        else {
+            return nil
+        }
+        
+        let ckcFileDir = try DownloadIndex.persistenKeyDirectory()
+        let fileURL = URL(fileURLWithPath: localFile, relativeTo: ckcFileDir)
+//        logger.info("Looking for CKC to file at: \(fileURL.path)")
+//        logger.info("Looking for CKC to file at (relative): \(fileURL.relativePath)")
+//        logger.info("Looking for CKC to file at (relative): \(fileURL)")
+        guard assetFileExists(at: fileURL) else {
+            logger.warning("CKC file doesn't exist for \(playbackID) at \(fileURL.absoluteString)")
+            return nil
+        }
+//        logger.trace("CKC file found for \(playbackID) at \(fileURL.absoluteString)")
+        // returns nil if there's a read error
+        return FileManager.default.contents(atPath: fileURL.path)
+    }
+    
+    /// Starts a new Download Task. If there was already a task in progress for this playbackID,
+    func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws {
+        // TODO: Save that dude to a file
+        //        try await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: ckcFileURL.relativePath)
+        
+        guard let asset = await index.get(playbackID: playbackID) else {
+            logger.warning("[Mux-Offline] tried to save persistent key for not-index playbackID: \(playbackID)")
+            // TODO: Should we throw?
+            return
+        }
+        
+        // Clean up old file if it exists
+        if let existingFile = asset.ckcFilePath {
+            let existingURL = URL(fileURLWithPath: existingFile, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
+            do {
+                try FileManager.default.removeItem(at: existingURL)
+            } catch {
+                logger.trace("Failed to delete existing CKC file (probably didn't exist): \(error)")
+            }
+        }
+        
+        let newCkcFileURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
+        //        logger.info("Saved CKC to file at: \(newCkcFileURL.path)")
+        //        logger.info("Saved CKC to file at (relative): \(newCkcFileURL)")
+        logger.info("Saving CKC to file at (relative): \(newCkcFileURL.relativePath)")
+        
+        // update index first. Better to have blank entries here than orphaned files on disk
+        await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: newCkcFileURL.relativePath)
+        
+        try FileManager.default.createDirectory(
+            at: DownloadIndex.persistenKeyDirectory(),
+            withIntermediateDirectories: true
+        )
+        try contentKeyData.write(to: newCkcFileURL)
+        
+        logger.info("Saved CKC to file at (relative): \(newCkcFileURL.relativePath)")
+        
+    }
+    
+    func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async {
+        await index.updateExpirationPhase(playbackID: playbackID, phase: phase)
+    }
+
     func allCompletedAssets() async -> [DownloadedAsset] {
-        await index.all()
+        let completedAssets = await index.all()
             .filter { $0.isComplete }
             .compactMap { completedAsset -> DownloadedAsset? in
                 guard let assetPath = completedAsset.localPath else {
@@ -133,12 +231,20 @@ actor DownloadManager {
                     return nil
                 }
                 let assetURL = URL(fileURLWithPath: assetPath, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
-                
-                // TODO: Check DRM expiration too
+                let urlAsset = AVURLAsset(url: assetURL)
+
+                if completedAsset.isExpired() {
+                    return DownloadedAsset(
+                        playbackID: completedAsset.playbackID,
+                        assetStatus: .expired,
+                        downloadOptions: DownloadOptions(from: completedAsset)
+                    )
+                }
+
                 if assetFileExists(at: assetURL), !completedAsset.completedWithError {
                     return DownloadedAsset(
                         playbackID: completedAsset.playbackID,
-                        assetStatus: .playable(asset: AVURLAsset(url: assetURL)),
+                        assetStatus: .playable(asset: urlAsset),
                         downloadOptions: DownloadOptions(from: completedAsset)
                     )
                 } else {
@@ -149,6 +255,14 @@ actor DownloadManager {
                     )
                 }
             }
+        
+        for asset in completedAssets {
+            if let urlAsset = asset.avAssetIfPlayable() {
+                await addDRMInfoTo(urlAsset, playbackID: asset.playbackID)
+            }
+        }
+        
+        return completedAssets
     }
     
     func allInProgressTasks() async -> [String: AnyPublisher<DownloadEvent, Error>] {
@@ -167,11 +281,11 @@ actor DownloadManager {
                 logger.warning("[Mux-Offline] reattachPendingDownloadPublishers: Missing playbackID (taskDescription) for task id=\(assetTask.taskIdentifier)")
                 continue
             }
-
+            
             downloadTasksByPlaybackID[playbackID] = assetTask
             let subject = subject(for: playbackID)
             publishers[playbackID] = subject.eraseToAnyPublisher()
-
+            
             assetTask.resume()
         }
         
@@ -185,6 +299,39 @@ actor DownloadManager {
         }
         return subject.eraseToAnyPublisher()
     }
+    
+    private func addDRMInfoTo(_ urlAsset: AVURLAsset, playbackID: String) async {
+        // TODO: try?
+        let persistedContentKey = await try? findPeristedContentKey(playbackID: playbackID)
+        // We are only sending to the main actor so we know this will be safe
+        if let persistedContentKey {
+            // We only need MainActor because PlayerSDK.shared is TaskLocal on debug
+            //                await MainActor.run {
+            // TODO: Can just store the key Data here
+            await PlayerSDK.shared.fairPlaySessionManager.addOfflinePlayDRMAsset(
+                urlAsset,
+                playbackID: playbackID,
+                keyData: persistedContentKey
+            )
+            //                }
+        }
+    }
+    
+    private func persistentKeyFile(playbackID: String, identifier: String) throws -> URL {
+        let sanitizedIdentifier = identifier.data(using: .utf8)?.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        guard let sanitizedIdentifier else {
+            throw FairPlaySessionError.unexpected(message: "Failed to santiize key identifier [\(identifier)]")
+        }
+        
+        let sanitizedName = "\(playbackID)-\(sanitizedIdentifier)"
+        let fileName = "\(sanitizedName).key"
+        let directoryURL = try DownloadIndex.persistenKeyDirectory()
+        return URL(fileURLWithPath: fileName, relativeTo: directoryURL)
+    }
+    
     
     private func assetFileExists(at movPkgURL: URL) -> Bool {
         return FileManager.default.fileExists(atPath: movPkgURL.path)
@@ -284,6 +431,9 @@ actor DownloadManager {
         await index.updateIsComplete(playbackID: playbackID, isComplete: true, completeWithError: true)
         // Once a task errors, we can't resume where we left off, so just delete any partially-downloaded data
         await index.deleteDownloadedFiles(playbackID: playbackID, removeFromIndex: false)
+        await MainActor.run {
+            PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
+        }
         
         // do these after the awaits, so callers that call startDownload to handle errors actually start one
         sendError(error, for: playbackID)
@@ -314,6 +464,14 @@ actor DownloadManager {
             return
         }
         
+        await MainActor.run {
+            PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
+        }
+
+        // Ensure localPath is set even if willDownloadTo's Task hasn't
+        // run yet (actor task scheduling is not FIFO)
+        await index.updateLocalPathURL(playbackID: playbackID, localPath: location.relativePath)
+
         let asset = AVURLAsset(url: location)
         let storedAsset = await index.updateIsComplete(playbackID: playbackID, isComplete: true, completeWithError: false)
         guard let storedAsset else {

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -85,6 +85,7 @@ actor DownloadManager {
         }
     }
     
+    /// Starts a new Download Task. If there was already a task in progress for this playbackID,
     /// tracks that task's progress instead of starting a new one.
     func startDownloadWithPublisher(
         playbackID: String,
@@ -152,14 +153,14 @@ actor DownloadManager {
     }
     
     /// If an asset is stored in the index (completed or not), and it has a persisted content key, returns it
-    func findPeristedContentKey(playbackID: String) async throws -> Data? {
+    func findPersistedContentKey(playbackID: String) async throws -> Data? {
         guard let storedAsset = await index.get(playbackID: playbackID),
               let localFile = storedAsset.ckcFilePath
         else {
             return nil
         }
         
-        let ckcFileDir = try DownloadIndex.persistenKeyDirectory()
+        let ckcFileDir = try DownloadIndex.persistentKeyDirectory()
         let fileURL = URL(fileURLWithPath: localFile, relativeTo: ckcFileDir)
         guard assetFileExists(at: fileURL) else {
             logger.warning("CKC file doesn't exist for \(playbackID) at \(fileURL.absoluteString)")
@@ -168,7 +169,6 @@ actor DownloadManager {
         return FileManager.default.contents(atPath: fileURL.path)
     }
     
-    /// Starts a new Download Task. If there was already a task in progress for this playbackID,
     func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws {
         guard let asset = await index.get(playbackID: playbackID) else {
             logger.warning("[Mux-Offline] tried to save persistent key for non-indexed playbackID: \(playbackID)")
@@ -176,7 +176,7 @@ actor DownloadManager {
         }
         
         try FileManager.default.createDirectory(
-            at: DownloadIndex.persistenKeyDirectory(),
+            at: DownloadIndex.persistentKeyDirectory(),
             withIntermediateDirectories: true
         )
 
@@ -288,7 +288,7 @@ actor DownloadManager {
     private func addDRMInfoTo(_ urlAsset: AVURLAsset, playbackID: String) async {
         let persistedContentKey: Data?
         do {
-            persistedContentKey = await try findPeristedContentKey(playbackID: playbackID)
+            persistedContentKey = await try findPersistedContentKey(playbackID: playbackID)
         } catch {
             logger.warning("Couldn't find persisted content key for \(playbackID): \(error)")
             return
@@ -309,12 +309,12 @@ actor DownloadManager {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
         guard let sanitizedIdentifier else {
-            throw FairPlaySessionError.unexpected(message: "Failed to santiize key identifier [\(identifier)]")
+            throw FairPlaySessionError.unexpected(message: "Failed to sanitize key identifier [\(identifier)]")
         }
         
         let sanitizedName = "\(playbackID)-\(sanitizedIdentifier)"
         let fileName = "\(sanitizedName).key"
-        let directoryURL = try DownloadIndex.persistenKeyDirectory()
+        let directoryURL = try DownloadIndex.persistentKeyDirectory()
         return URL(fileURLWithPath: fileName, relativeTo: directoryURL)
     }
     

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -200,6 +200,7 @@ actor DownloadManager {
         
         logger.info("Saved CKC to file at: \(newCkcFileURL.absoluteString)")
         
+        PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
     }
     
     func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async {
@@ -446,8 +447,6 @@ actor DownloadManager {
             logger.debug("[Mux-Offline] Ignoring stale error callback for playbackID \(playbackID), task id=\(task.taskIdentifier)")
             return
         }
-        
-        PlayerSDK.shared.fairPlaySessionManager.removeOfflineDownloadSession(playbackID: playbackID)
 
         // Ensure localPath is set even if willDownloadTo's Task hasn't
         // run yet (actor task scheduling is not FIFO)

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -128,7 +128,7 @@ actor DownloadManager {
         await index.upsert(StoredAsset.forNewDownload(playbackID: playbackID, options: downloadOptions, drmClaims: drmClaims))
         
         // Adds the asset as a ContentKeyRecipient, if it's DRM-protected
-        if case .drm(let drmOptions) = playbackOptions.playbackPolicy {
+        if case .drm(_) = playbackOptions.playbackPolicy {
             PlayerSDK.shared.registerOfflineDRMAsset(avAsset, playbackID: playbackID, playbackOptions: playbackOptions)
         }
         
@@ -181,7 +181,7 @@ actor DownloadManager {
         )
 
         // Clean up old file if it exists
-        if let existingFile = asset.ckcFilePath {
+        if asset.ckcFilePath != nil {
             let existingURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
             do {
                 try FileManager.default.removeItem(at: existingURL)
@@ -194,7 +194,7 @@ actor DownloadManager {
         logger.info("Saving CKC to file at: \(newCkcFileURL.relativePath)")
         
         // update index first. Better to have blank entries here than orphaned files on disk
-        await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: newCkcFileURL.relativePath)
+        let _ = await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: newCkcFileURL.relativePath)
         
         try contentKeyData.write(to: newCkcFileURL)
         

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -288,7 +288,7 @@ actor DownloadManager {
     private func addDRMInfoTo(_ urlAsset: AVURLAsset, playbackID: String) async {
         let persistedContentKey: Data?
         do {
-            persistedContentKey = await try findPersistedContentKey(playbackID: playbackID)
+            persistedContentKey = try await findPersistedContentKey(playbackID: playbackID)
         } catch {
             logger.warning("Couldn't find persisted content key for \(playbackID): \(error)")
             return

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -301,24 +301,6 @@ actor DownloadManager: PersistedKeyStore {
         }
     }
     
-    private func addDRMInfoTo(_ urlAsset: AVURLAsset, playbackID: String) async {
-        let persistedContentKey: Data?
-        do {
-            persistedContentKey = try await findPersistedContentKey(playbackID: playbackID)
-        } catch {
-            logger.warning("Couldn't find persisted content key for \(playbackID): \(error)")
-            return
-        }
-        // We are only sending to the main actor so we know this will be safe
-        if let persistedContentKey {
-            await PlayerSDK.shared.fairPlaySessionManager.addOfflinePlayDRMAsset(
-                urlAsset,
-                playbackID: playbackID,
-                keyData: persistedContentKey
-            )
-        }
-    }
-    
     private func persistentKeyFile(playbackID: String, identifier: String) throws -> URL {
         let sanitizedIdentifier = identifier.data(using: .utf8)?.base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -183,7 +183,7 @@ actor DownloadManager {
         
         // Clean up old file if it exists
         if let existingFile = asset.ckcFilePath {
-            let existingURL = URL(fileURLWithPath: existingFile, relativeTo: URL(fileURLWithPath: NSHomeDirectory()))
+            let existingURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
             do {
                 try FileManager.default.removeItem(at: existingURL)
             } catch {
@@ -191,19 +191,20 @@ actor DownloadManager {
             }
         }
         
-        let newCkcFileURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
-        logger.info("Saving CKC to file at (relative): \(newCkcFileURL.relativePath)")
-        
-        // update index first. Better to have blank entries here than orphaned files on disk
-        await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: newCkcFileURL.relativePath)
-        
         try FileManager.default.createDirectory(
             at: DownloadIndex.persistenKeyDirectory(),
             withIntermediateDirectories: true
         )
+        
+        let newCkcFileURL = try persistentKeyFile(playbackID: playbackID, identifier: identifier)
+        logger.info("Saving CKC to file at: \(newCkcFileURL.relativePath)")
+        
+        // update index first. Better to have blank entries here than orphaned files on disk
+        await index.updateCKCFileURL(playbackID: playbackID, ckcFilePath: newCkcFileURL.relativePath)
+        
         try contentKeyData.write(to: newCkcFileURL)
         
-        logger.info("Saved CKC to file at (relative): \(newCkcFileURL.relativePath)")
+        logger.info("Saved CKC to file at: \(newCkcFileURL.absoluteString)")
         
     }
     

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -92,7 +92,7 @@ actor DownloadManager {
         downloadOptions: DownloadOptions,
         playbackOptions: PlaybackOptions
     ) async -> AnyPublisher<DownloadEvent, Error> {
-        print("--- URL I'm Downloading: \(avAsset.url)")
+        logger.trace("Downloading: \(avAsset.url)")
         
         // If we already have a completed asset, return it. Caller can use it, or if it's not playable, they can explicitly delete
         let alreadyCompletedAsset = await findDownloadedAsset(playbackID: playbackID)

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -16,7 +16,7 @@ import os
 // media are isolated here internally. This actor is intended to be called from the external API, `Mux-OfflineAccessManager`,
 // which calls through to this actor without introducing reentrancy issues, or requiring any particular concurrency
 // management from the caller
-actor DownloadManager {
+actor DownloadManager: PersistedKeyStore {
     private let delegateQueue: OperationQueue = {
         let q = OperationQueue()
         q.name = "com.mux.offline.delegate"
@@ -470,4 +470,10 @@ actor DownloadManager {
         downloadTasksByPlaybackID[playbackID] = nil
         detachEvents(for: playbackID)
     }
+}
+
+protocol PersistedKeyStore {
+    func findPersistedContentKey(playbackID: String) async throws -> Data?
+    func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws
+    func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async
 }

--- a/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
+++ b/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
@@ -31,8 +31,8 @@ struct StoredAsset: Codable {
     let redownloadExpiration: Date?
 
     // DRM expiration fields
-    /// When the asset was first downloaded (license creation time)
-    let downloadedAt: Date?
+    /// The start time for computing license expiration
+    let expireLicenseFrom: Date?
     /// Which expiration period applies
     let expirationPhase: ExpirationPhase?
     /// Seconds from license creation until expiration (from JWT licenseExpiration claim)
@@ -41,7 +41,7 @@ struct StoredAsset: Codable {
     let playDurationDuration: TimeInterval?
 
     func isExpired(at now: Date = Date()) -> Bool {
-        guard let downloadedAt else { return false }
+        guard let expireLicenseFrom else { return false }
 
         let duration: TimeInterval?
         switch expirationPhase {
@@ -54,7 +54,7 @@ struct StoredAsset: Codable {
         }
 
         guard let duration else { return false }
-        return now > downloadedAt.addingTimeInterval(duration)
+        return now > expireLicenseFrom.addingTimeInterval(duration)
     }
 }
 
@@ -76,7 +76,7 @@ extension StoredAsset {
             secondaryAudioLanguages: options.secondaryAudioLanguages,
             ckcFilePath: nil,
             redownloadExpiration: nil,
-            downloadedAt: hasDRM ? Date() : nil,
+            expireLicenseFrom: hasDRM ? Date() : nil,
             expirationPhase: hasDRM ? .licenseExpiration : nil,
             licenseExpirationDuration: drmClaims?.licenseExpiration,
             playDurationDuration: drmClaims?.playDuration

--- a/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
+++ b/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
@@ -7,27 +7,64 @@
 
 import Foundation
 
+enum ExpirationPhase: String, Codable {
+    /// Expiration is based on licenseExpiration (not yet played offline)
+    case licenseExpiration
+    /// Expiration is based on playDuration (played at least once offline)
+    case playDuration
+}
+
 // internal DTO for our index of downloaded assets
 struct StoredAsset: Codable {
     let isComplete: Bool
     let completedWithError: Bool
-    
+
     let playbackID: String
     let localPath: String?
     let readableTitle: String
     let posterDataBase64: String?
     let subtitleLanguages: [String]?
     let secondaryAudioLanguages: [String]?
-    
+
     let ckcFilePath: String?
-    /// For DRM keys: Either storage or play expiration depending on state
-    let keyExpiration: Date?
     /// For secure playback: playback token expiration
     let redownloadExpiration: Date?
+
+    // DRM expiration fields
+    /// When the asset was first downloaded (license creation time)
+    let downloadedAt: Date?
+    /// Which expiration period applies
+    let expirationPhase: ExpirationPhase?
+    /// Seconds from license creation until expiration (from JWT licenseExpiration claim)
+    let licenseExpirationDuration: TimeInterval?
+    /// Seconds from first offline playback until expiration (from JWT playDuration claim)
+    let playDurationDuration: TimeInterval?
+
+    func isExpired(at now: Date = Date()) -> Bool {
+        guard let downloadedAt else { return false }
+
+        let duration: TimeInterval?
+        switch expirationPhase {
+        case .playDuration:
+            duration = playDurationDuration
+        case .licenseExpiration:
+            duration = licenseExpirationDuration
+        case nil:
+            return false
+        }
+
+        guard let duration else { return false }
+        return now > downloadedAt.addingTimeInterval(duration)
+    }
 }
 
 extension StoredAsset {
-    static func forNewDownload(playbackID: String, options: DownloadOptions) -> StoredAsset {
+    static func forNewDownload(
+        playbackID: String,
+        options: DownloadOptions,
+        drmClaims: DRMTokenClaims? = nil
+    ) -> StoredAsset {
+        let hasDRM = drmClaims != nil
         return StoredAsset(
             isComplete: false,
             completedWithError: false,
@@ -38,8 +75,11 @@ extension StoredAsset {
             subtitleLanguages: options.subtitleLanguages,
             secondaryAudioLanguages: options.secondaryAudioLanguages,
             ckcFilePath: nil,
-            keyExpiration: nil,
-            redownloadExpiration: nil
+            redownloadExpiration: nil,
+            downloadedAt: hasDRM ? Date() : nil,
+            expirationPhase: hasDRM ? .licenseExpiration : nil,
+            licenseExpirationDuration: drmClaims?.licenseExpiration,
+            playDurationDuration: drmClaims?.playDuration
         )
     }
 }
@@ -49,18 +89,18 @@ extension StoredAsset: CustomDebugStringConvertible {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
-        
+
         let data: Data
         do {
             data = try encoder.encode(self)
         } catch {
             return "StoredAsset(playbackID: \(playbackID), encoding failed: \(error))"
         }
-        
+
         guard let jsonString = String(data: data, encoding: .utf8) else {
             return "StoredAsset(playbackID: \(playbackID), encoding failed)"
         }
-        
+
         return jsonString
     }
 }

--- a/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
+++ b/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
@@ -36,9 +36,9 @@ struct StoredAsset: Codable {
     /// Which expiration period applies
     let expirationPhase: ExpirationPhase?
     /// Seconds from license creation until expiration (from JWT licenseExpiration claim)
-    let licenseExpirationDuration: TimeInterval?
+    let licenseExpirationSeconds: TimeInterval?
     /// Seconds from first offline playback until expiration (from JWT playDuration claim)
-    let playDurationDuration: TimeInterval?
+    let playDurationSeconds: TimeInterval?
 
     func isExpired(at now: Date = Date()) -> Bool {
         guard let expireLicenseFrom else { return false }
@@ -46,9 +46,9 @@ struct StoredAsset: Codable {
         let duration: TimeInterval?
         switch expirationPhase {
         case .playDuration:
-            duration = playDurationDuration
+            duration = playDurationSeconds
         case .licenseExpiration:
-            duration = licenseExpirationDuration
+            duration = licenseExpirationSeconds
         case nil:
             return false
         }
@@ -78,8 +78,8 @@ extension StoredAsset {
             redownloadExpiration: nil,
             expireLicenseFrom: hasDRM ? Date() : nil,
             expirationPhase: hasDRM ? .licenseExpiration : nil,
-            licenseExpirationDuration: drmClaims?.licenseExpiration,
-            playDurationDuration: drmClaims?.playDuration
+            licenseExpirationSeconds: drmClaims?.licenseExpiration,
+            playDurationSeconds: drmClaims?.playDuration
         )
     }
 }

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
@@ -90,7 +90,7 @@ public class MuxOfflineAccessManager {
         return await manager.allCompletedAssets()
     }
     
-    public init() {
+    private init() {
         PlayerSDK.shared.diagnosticsLogger.info("initializing MuxOfflineAccessManager")
     }
 }

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
@@ -13,13 +13,13 @@ import os
 public class MuxOfflineAccessManager {
     public static let shared = MuxOfflineAccessManager()
     
-    private let manager: DownloadManager = DownloadManager()
+    internal let manager: DownloadManager = DownloadManager()
     
-    #if DEBUG
+#if DEBUG
     private let logger = Logger(OSLog(subsystem: "com.mux.player", category: "Mux-Offline"))
-    #else
+#else
     private let logger = Logger(.disabled)
-    #endif
+#endif
     
     /// Start downloading a video for offline access.
     /// Only one download per playbackID may be saved at once. If you want to re-download media for the same playbackID
@@ -43,8 +43,14 @@ public class MuxOfflineAccessManager {
         }
         
         let asset = AVURLAsset(url: url)
+        
         return await manager
-            .startDownloadWithPublisher(playbackID: playbackID, avAsset: asset, options: downloadOptions)
+            .startDownloadWithPublisher(
+                playbackID: playbackID,
+                avAsset: asset,
+                downloadOptions: downloadOptions,
+                playbackOptions: playbackOptions
+            )
             .toAsyncThrowingStream()
     }
     
@@ -82,5 +88,9 @@ public class MuxOfflineAccessManager {
     /// - Returns: An array of all downloaded assets
     public func allDownloadedAssets() async -> [DownloadedAsset] {
         return await manager.allCompletedAssets()
+    }
+    
+    public init() {
+        PlayerSDK.shared.diagnosticsLogger.info("initializing MuxOfflineAccessManager")
     }
 }

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
@@ -90,7 +90,7 @@ public class MuxOfflineAccessManager {
         return await manager.allCompletedAssets()
     }
     
-    private init() {
+    internal init() {
         PlayerSDK.shared.diagnosticsLogger.info("initializing MuxOfflineAccessManager")
     }
 }

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -300,4 +300,50 @@ class ContentKeySessionDelegateTests : XCTestCase {
         }
     }
 
+    // MARK: - handleContentKeyUpdated tests
+
+    func testContentKeyUpdated_HappyPath_SavesKey() async throws {
+        let fakeKeyData = "updated-key-data".data(using: .utf8)!
+        let keyIdentifier = makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+
+        try await contentKeySessionDelegate.handleContentKeyUpdated(
+            keyIdentifier: keyIdentifier,
+            data: fakeKeyData
+        )
+
+        XCTAssertEqual(mockKeyStore.savedKeys.count, 1)
+        XCTAssertEqual(mockKeyStore.savedKeys.first?.playbackID, "fake-playback")
+        XCTAssertEqual(mockKeyStore.savedKeys.first?.identifier, keyIdentifier)
+        XCTAssertEqual(mockKeyStore.savedKeys.first?.data, fakeKeyData)
+    }
+
+    func testContentKeyUpdated_NonStringIdentifier_DoesNotSave() async throws {
+        try await contentKeySessionDelegate.handleContentKeyUpdated(
+            keyIdentifier: 12345,
+            data: "some-data".data(using: .utf8)!
+        )
+
+        XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
+    }
+
+    func testContentKeyUpdated_InvalidURL_DoesNotSave() async throws {
+        try await contentKeySessionDelegate.handleContentKeyUpdated(
+            keyIdentifier: "not a url \n\n",
+            data: "some-data".data(using: .utf8)!
+        )
+
+        XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
+    }
+
+    func testContentKeyUpdated_MissingPlaybackId_DoesNotSave() async throws {
+        let keyIdentifier = makeFakeSkdUrlIncorrect()
+
+        try await contentKeySessionDelegate.handleContentKeyUpdated(
+            keyIdentifier: keyIdentifier,
+            data: "some-data".data(using: .utf8)!
+        )
+
+        XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
+    }
+
 }

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -141,7 +141,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
         
-        contentKeySessionDelegate.handleSpcObtainedFromCDM(
+        contentKeySessionDelegate.handleSpcObtainedFromCDMForOnlineKey(
             spcData: "fake-spc-data".data(using: .utf8)!,
             playbackID: "fake-playback",
             request: mockRequest
@@ -169,7 +169,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
             options: .init(playbackToken: "playback-token", drmToken: "drm-token"),
             rootDomain: "example.com")
 
-        contentKeySessionDelegate.handleSpcObtainedFromCDM(
+        contentKeySessionDelegate.handleSpcObtainedFromCDMForOnlineKey(
             spcData: "fake-spc-data".data(using: .utf8)!,
             playbackID: "fake-playback",
             request: mockRequest

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -27,9 +27,17 @@ class ContentKeySessionDelegateTests : XCTestCase {
     }
     
     private func setUpForFailure(error: FairPlaySessionError) {
-        testCredentialClient = TestFairPlayStreamingSessionCredentialClient(
-            failsWith: error
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                failsWith: error
+            )
         )
+    }
+
+    private func setUpWith(
+        credentialClient: TestFairPlayStreamingSessionCredentialClient
+    ) {
+        testCredentialClient = credentialClient
         testDRMAssetRegistry = TestDRMAssetRegistry()
         mockKeyStore = MockPersistedKeyStore()
         testSessionManager = TestFairPlayStreamingSessionManager(
@@ -285,7 +293,11 @@ class ContentKeySessionDelegateTests : XCTestCase {
     }
 
     func testPersistableKeyRequest_CertError_Throws() async {
-        setUpForFailure(error: .unexpected(message: "cert error"))
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                certFailsWith: .unexpected(message: "cert error")
+            )
+        )
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
@@ -297,6 +309,41 @@ class ContentKeySessionDelegateTests : XCTestCase {
             XCTAssertTrue(
                 mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
             )
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(
+                    funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+                )
+            )
+        }
+    }
+
+    func testPersistableKeyRequest_LicenseError_Throws() async {
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                fakeCert: "fake-cert".data(using: .utf8)!,
+                licenseFailsWith: .unexpected(message: "license error")
+            )
+        )
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        do {
+            try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Should have gotten past cert and SPC stages
+            XCTAssertTrue(
+                mockRequest.verifyWasCalled(
+                    funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+                )
+            )
+            // But should not have processed a response
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+            // Should not have saved any key
+            XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
         }
     }
 

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -15,7 +15,8 @@ class ContentKeySessionDelegateTests : XCTestCase {
     var testDRMAssetRegistry: TestDRMAssetRegistry!
     var testCredentialClient: TestFairPlayStreamingSessionCredentialClient!
     var testSessionManager: TestFairPlayStreamingSessionManager!
-    
+    var mockKeyStore: MockPersistedKeyStore!
+
     // object under test
     var contentKeySessionDelegate: ContentKeySessionDelegate<
         TestFairPlayStreamingSessionManager
@@ -30,31 +31,35 @@ class ContentKeySessionDelegateTests : XCTestCase {
             failsWith: error
         )
         testDRMAssetRegistry = TestDRMAssetRegistry()
+        mockKeyStore = MockPersistedKeyStore()
         testSessionManager = TestFairPlayStreamingSessionManager(
             credentialClient: testCredentialClient,
             drmAssetRegistry: testDRMAssetRegistry
         )
-        
+
         contentKeySessionDelegate = ContentKeySessionDelegate(
-            sessionManager: testSessionManager  
+            sessionManager: testSessionManager,
+            persistedKeyStore: mockKeyStore
         )
     }
-    
+
     private func setUpForSuccess() {
         testCredentialClient = TestFairPlayStreamingSessionCredentialClient(
             fakeCert: "default fake cert".data(using: .utf8)!,
             fakeLicense: "default fake license".data(using: .utf8)!
         )
-        
+
         testDRMAssetRegistry = TestDRMAssetRegistry()
+        mockKeyStore = MockPersistedKeyStore()
 
         testSessionManager = TestFairPlayStreamingSessionManager(
             credentialClient: testCredentialClient,
             drmAssetRegistry: testDRMAssetRegistry
         )
-        
+
         contentKeySessionDelegate = ContentKeySessionDelegate(
-            sessionManager: testSessionManager  
+            sessionManager: testSessionManager,
+            persistedKeyStore: mockKeyStore
         )
     }
     
@@ -174,7 +179,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
             playbackID: "fake-playback",
             request: mockRequest
         )
-        
+
         XCTAssertTrue(
             mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
         )
@@ -182,5 +187,117 @@ class ContentKeySessionDelegateTests : XCTestCase {
             mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")
         )
     }
-    
+
+    // MARK: - handlePersistableContentKeyRequest tests
+
+    func testPersistableKeyRequest_NilSessionManager_Throws() async {
+        contentKeySessionDelegate.sessionManager = nil
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        do {
+            try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
+    }
+
+    func testPersistableKeyRequest_InvalidIdentifier_Returns() async throws {
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: 12345 // non-string identifier
+        )
+
+        try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+        )
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
+        )
+    }
+
+    func testPersistableKeyRequest_MissingPlaybackId_Throws() async {
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrlIncorrect()
+        )
+
+        do {
+            try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
+    }
+
+    func testPersistableKeyRequest_ExistingPersistedKey_UsesItDirectly() async throws {
+        let fakeKeyData = "persisted-key-data".data(using: .utf8)!
+        mockKeyStore.persistedKeys["fake-playback"] = fakeKeyData
+
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+
+        // Should use persisted key directly
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")
+        )
+        // Should not request cert or license
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)")
+        )
+        // Should update expiration phase
+        XCTAssertEqual(mockKeyStore.updatedPhases.count, 1)
+        XCTAssertEqual(mockKeyStore.updatedPhases.first?.playbackID, "fake-playback")
+        XCTAssertEqual(mockKeyStore.updatedPhases.first?.phase, .playDuration)
+    }
+
+    func testPersistableKeyRequest_NoPersistedKey_FetchesAndSaves() async throws {
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+
+        // Should have requested SPC and processed a response
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
+        )
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "persistableContentKey(fromKeyVendorResponse:options:)")
+        )
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")
+        )
+        // Should have saved the key
+        XCTAssertEqual(mockKeyStore.savedKeys.count, 1)
+        XCTAssertEqual(mockKeyStore.savedKeys.first?.playbackID, "fake-playback")
+    }
+
+    func testPersistableKeyRequest_CertError_Throws() async {
+        setUpForFailure(error: .unexpected(message: "cert error"))
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        do {
+            try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
+    }
+
 }

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -92,104 +92,98 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertEqual(fakePlaybackID, foundPlaybackID)
     }
     
-    func testKeyRequestNoPlaybackId() throws {
+    func testKeyRequestNoPlaybackId() async {
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrlIncorrect()
         )
-        
-        contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-        
+
+        do {
+            try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+        } catch {
+            // error is acceptable here too
+        }
+
         XCTAssertTrue(
             mockRequest.verifyWasCalled(
                 funcName: "processContentKeyResponseError"
             )
         )
         XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "makeStreamingContentKeyRequestData")
+            mockRequest.verifyNotCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
         )
     }
-    
-    func testKeyRequestCertError() throws {
-        setUpForFailure(error: .unexpected(message: "fake error"))
+
+    func testKeyRequestCertError() async {
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                certFailsWith: .unexpected(message: "cert error")
+            )
+        )
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
-        
-        contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-        XCTAssertTrue(
-            mockRequest.verifyWasCalled(
-                funcName: "processContentKeyResponseError"
+
+        do {
+            try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(
+                    funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+                )
+            )
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
+    }
+
+    func testKeyRequestLicenseError() async {
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                fakeCert: "fake-cert".data(using: .utf8)!,
+                licenseFailsWith: .unexpected(message: "license error")
             )
         )
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "makeStreamingContentKeyRequestData")
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
+
+        do {
+            try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Should have gotten past cert and SPC stages
+            XCTAssertTrue(
+                mockRequest.verifyWasCalled(
+                    funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+                )
+            )
+            // But should not have processed a response
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
     }
-    
-    func testKeyRequestHappyPath() throws {
+
+    func testKeyRequestHappyPath() async throws {
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(
                 fakePlaybackID: "fake-playback"
             )
         )
-        testDRMAssetRegistry.addDRMAsset(
-            AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
-            playbackID: "fake-playback",
-            options: .init(playbackToken: "playback-token", drmToken: "drm-token"),
-            rootDomain: "example.com")
 
-        contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-        
+        try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+
         XCTAssertTrue(
             mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
         )
-        XCTAssertTrue(
-            mockRequest.verifyWasCalled(funcName: "makeStreamingContentKeyRequestData")
-        )
-    }
-    
-    func testSPCForCKCFailedLicense() throws {
-        setUpForFailure(error: .unexpected(message: "fake error"))
-        let mockRequest = MockKeyRequest(
-            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
-        )
-        
-        contentKeySessionDelegate.handleSpcObtainedFromCDMForOnlineKey(
-            spcData: "fake-spc-data".data(using: .utf8)!,
-            playbackID: "fake-playback",
-            request: mockRequest
-        )
-        
         XCTAssertTrue(
             mockRequest.verifyWasCalled(
-                funcName: "processContentKeyResponseError"
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
             )
-        )
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
-        )
-    }
-    
-    func testSPCForCKCHappyPath() throws {
-        let mockRequest = MockKeyRequest(
-            fakeIdentifier: makeFakeSkdUrl(
-                fakePlaybackID: "fake-playback"
-            )
-        )
-        testDRMAssetRegistry.addDRMAsset(
-            AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
-            playbackID: "fake-playback",
-            options: .init(playbackToken: "playback-token", drmToken: "drm-token"),
-            rootDomain: "example.com")
-
-        contentKeySessionDelegate.handleSpcObtainedFromCDMForOnlineKey(
-            spcData: "fake-spc-data".data(using: .utf8)!,
-            playbackID: "fake-playback",
-            request: mockRequest
-        )
-
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
         )
         XCTAssertTrue(
             mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")

--- a/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
@@ -15,10 +15,6 @@ class FairPlaySessionManagerTests : XCTestCase {
     
     // object under test
     private var sessionManager: FairPlayStreamingSessionManager!
-    
-    // FairPlayStreamingSessionManager expects most of these calls to come from AVContentKeySession,
-    // so send them from this queue to avoid memory corruption in the DRM config lookup
-    private var targetQueue: DispatchQueue!
 
     override func setUp() {
         super.setUp()
@@ -26,7 +22,6 @@ class FairPlaySessionManagerTests : XCTestCase {
         mockURLSessionConfig.protocolClasses = [MockURLProtocol.self]
         let session = TestContentKeySession()
         let queue = DispatchQueue(label: "test target queue")
-        self.targetQueue = queue
         let defaultFairPlaySessionManager = DefaultFairPlayStreamingSessionManager(
             contentKeySession: session,
             errorDispatcher: Monitor(),
@@ -95,13 +90,13 @@ class FairPlaySessionManagerTests : XCTestCase {
         )
     }
     
-    func testAppCertificateRequestBody() throws {
+    func testAppCertificateRequestBody() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
@@ -113,44 +108,35 @@ class FairPlaySessionManagerTests : XCTestCase {
             // response is not part of this test
             return (HTTPURLResponse(), nil)
         }
-        
-        let requestEnds = XCTestExpectation(description: "request ends")
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                // we recorded the request so we should be ok
-                requestEnds.fulfill()
-            }
-        }
-        wait(for: [requestEnds])
-        
+
+        _ = try? await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
+
         let urlComponents = URLComponents(string: urlRequest.url!.absoluteString)!
         XCTAssertNotNil(urlComponents.queryItems)
         XCTAssert(urlComponents.queryItems!.count > 0)
-        
+
         let tokenParam = urlComponents.queryItems!.first { it in it.name == "token"}
         let playbackID = urlRequest.url!.lastPathComponent
 
         XCTAssertNotNil(tokenParam)
         XCTAssertEqual(tokenParam?.name, "token")
         XCTAssertEqual(tokenParam?.value, fakeDrmToken)
-        
+
         XCTAssertEqual(playbackID, fakePlaybackId)
 
         XCTAssertEqual(urlRequest.httpMethod, "GET")
         // note: url tested using testMakeAppCertificateURL
     }
     
-    func testLicenseRequestBody() throws {
+    func testLicenseRequestBody() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         // real SPC's are opaque binary to us, the fake one can be whatever
         let fakeSpcData = "fake-SPC-binary-data".data(using: .utf8)!
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
@@ -159,7 +145,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         var urlRequest: URLRequest!
         MockURLProtocol.requestHandler = { request in
             urlRequest = request
-            
+
             // response is not part of this test
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -169,24 +155,13 @@ class FairPlaySessionManagerTests : XCTestCase {
             )!
             return (response, "fake ckc data".data(using: .utf8))
         }
-        
-        let requestEnds = XCTestExpectation(description: "request ends")
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                // we recorded the request so we should be ok
-                requestEnds.fulfill()
-            }
-        }
-        wait(for: [requestEnds])
-        
+
+        _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
+
         let urlComponents = URLComponents(string: urlRequest.url!.absoluteString)!
         XCTAssertNotNil(urlComponents.queryItems)
         XCTAssert(urlComponents.queryItems!.count > 0)
-        
+
         let tokenParam = urlComponents.queryItems!.first { it in it.name == "token"}
         let playbackID = urlRequest.url!.lastPathComponent
 
@@ -195,13 +170,13 @@ class FairPlaySessionManagerTests : XCTestCase {
         XCTAssertEqual(tokenParam?.value, fakeDrmToken)
 
         XCTAssertEqual(playbackID, fakePlaybackId)
-        
+
         // unfortunately we can't test the body for some reason, it's always nil even
         //  when intercepting with URLProtocol
         //XCTAssertEqual(urlRequest.httpBody, fakeSpcData)
-        
+
         XCTAssertEqual(urlRequest.httpMethod, "POST")
-        
+
         let headers = urlRequest.allHTTPHeaderFields
         guard let headers = headers, headers.count > 0 else {
             XCTFail("Request for License/CKC must have length and content type")
@@ -213,21 +188,20 @@ class FairPlaySessionManagerTests : XCTestCase {
         XCTAssertEqual(contentTypeHeader, "application/octet-stream")
     }
 
-    func testRequestCertificateSuccess() throws {
+    func testRequestCertificateSuccess() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         // real app certs are opaque binary to us, the fake one can be whatever
-        let fakeAppCert = "fake-application-cert-binary-data".data(using: .utf8)
-        
-        sessionManager.addDRMAsset(
+        let fakeAppCert = "fake-application-cert-binary-data".data(using: .utf8)!
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestCompleted = XCTestExpectation(description: "request certificate completion")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -235,37 +209,26 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, fakeAppCert)
         }
-        
-        var requestResult: Result<Data, FairPlaySessionError>!
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                requestResult = result
-                requestCompleted.fulfill()
-            }
-        }
-        wait(for: [requestCompleted])
-        XCTAssertEqual(try requestResult.get(), fakeAppCert)
+
+        let result = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
+        XCTAssertEqual(result, fakeAppCert)
     }
-    
-    func testRequestCertificateHttpError() throws {
+
+    func testRequestCertificateHttpError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         let fakeHTTPStatus = 500 // all codes are handled the same way, by failing
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -273,107 +236,62 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
-            // failed requests proxied from our drm vendor have response bodies with
-            //   base64 text, which we should treat as opaque (not parse or decode),
-            //   since can't do anything with them and Cast logs them on the backend
             let errorBody = "failed request source text"
-            let errorData = errorBody.data(using: .utf8) // crashes if processed probably
-            return (
-                response,
-                errorData
-            )
+            let errorData = errorBody.data(using: .utf8)
+            return (response, errorData)
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
 
+        do {
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            if case .httpFailed(let code) = fpsError {
+                XCTAssertEqual(code, fakeHTTPStatus)
+            } else {
+                XCTFail("HTTP failure not reported with .httpFailed()")
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        if case .httpFailed(let code) = fpsError {
-            XCTAssertEqual(code, fakeHTTPStatus)
-        } else {
-            XCTFail("HTTP failure not reported with .httpFailed()")
-        }
     }
-    
-    func testRequestCertificateIOError() throws {
+
+    func testRequestCertificateIOError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
 
-        sessionManager.addDRMAsset(
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             throw FakeError()
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .because(_) = fpsError else {
+                XCTFail("I/O Failure should report a cause")
+                return
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .because(_) = fpsError else {
-            XCTFail("I/O Failure should report a cause")
-            return
-        }
-        
-        // If we make it here, we succeeded
     }
-    
-    func testRequestCertificateBlankWithSusStatusCode() throws {
+
+    func testRequestCertificateBlankWithSusStatusCode() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        // In this case, there's a successful response but no body
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate suspicious 200/OK should be treated as failure")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -381,55 +299,35 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, nil)
         }
-        
-        // Expected behavior: URLTask does something odd, requestCertificate returns error
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                    requestFails.fulfill()
-                }
+
+        do {
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .unexpected(let message) = fpsError else {
+                XCTFail("An Unexpected error should be returned")
+                return
             }
+            XCTAssert(message == "No cert data with 200 OK response")
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .unexpected(let message) = fpsError else {
-            XCTFail("An Unexpected error should be returned")
-            return
-        }
-        XCTAssert(message == "No cert data with 200 OK response")
     }
     
-    func testRequestLicenseSuccess() throws {
+    func testRequestLicenseSuccess() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
-        // to be returned by call under test
-        let fakeLicense = "fake-license-binary-data".data(using: .utf8)
-        
-        sessionManager.addDRMAsset(
+        let fakeLicense = "fake-license-binary-data".data(using: .utf8)!
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestSuccess = XCTestExpectation(description: "request license successfully")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -437,41 +335,27 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, fakeLicense)
         }
-        
-        var requestResult: Result<Data, FairPlaySessionError>!
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                requestResult = result
-                requestSuccess.fulfill()
-            }
-        }
-        wait(for: [requestSuccess])
-        XCTAssertEqual(try requestResult.get(), fakeLicense)
+
+        let result = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
+        XCTAssertEqual(result, fakeLicense)
     }
-    
-    func testLicenseRequestHttpError() throws {
+
+    func testLicenseRequestHttpError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        let fakeHTTPStatus = 500 // all codes are handled the same way, by failing
-        // real SPCs are opaque binary to us, the fake one can be whatever
+        let fakeHTTPStatus = 500
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -479,112 +363,64 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
-            // failed requests proxied from our drm vendor have response bodies with
-            //   base64 text, which we should treat as opaque (not parse or decode),
-            //   since we can't do anything with them and Cast logs them on the backend
             let errorBody = "failed request source text"
-            let errorData = errorBody.data(using: .utf8) // crashes if processed probably
-            return (
-                response,
-                errorData
-            )
+            let errorData = errorBody.data(using: .utf8)
+            return (response, errorData)
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            if case .httpFailed(let code) = fpsError {
+                XCTAssertEqual(code, fakeHTTPStatus)
+            } else {
+                XCTFail("HTTP failure not reported with .httpFailed()")
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        if case .httpFailed(let code) = fpsError {
-            XCTAssertEqual(code, fakeHTTPStatus)
-        } else {
-            XCTFail("HTTP failure not reported with .httpFailed()")
-        }
     }
-    
-    func testRequestLicenseIOError() throws {
+
+    func testRequestLicenseIOError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
 
-        sessionManager.addDRMAsset(
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             throw FakeError()
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                do {
-                    let data = try result.get()
-                    XCTFail("failure should have been reported, but got \(String(describing: data))")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .because(_) = fpsError else {
+                XCTFail("I/O Failure should report a cause")
+                return
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .because(_) = fpsError else {
-            XCTFail("I/O Failure should report a cause")
-            return
-        }
-        
-        // If we make it here, we succeeded
     }
-    
-    func testRequestLicenseBlankWithSusStatusCode() throws {
+
+    func testRequestLicenseBlankWithSusStatusCode() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        // In this case, there's a successful response but no body
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
 
-        sessionManager.addDRMAsset(
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate suspicious 200/OK should be treated as failure")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -592,39 +428,19 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, nil)
         }
-        
-        // Expected behavior: URLTask does something odd, requestCertificate returns error
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .unexpected(let message) = fpsError else {
+                XCTFail("unexpected failure should be returned")
+                return
             }
+            XCTAssert(message == "No license data with 200 response")
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .unexpected(let message) = fpsError else {
-            XCTFail("unexpected failure should be returned")
-            return
-        }
-        XCTAssert(message == "No license data with 200 response")
     }
 
     func testPlaybackOptionsRegistered() throws {

--- a/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
@@ -636,30 +636,29 @@ class FairPlaySessionManagerTests : XCTestCase {
             monitor: Monitor()
         )
 
-//        PlayerSDK.$shared.withValue(testSDK) {
-            var registeredAsset: AVURLAsset!
+        var registeredAsset: AVURLAsset!
 
-            let registeredExpectation = XCTestExpectation(description: "DRM asset should be registered")
-            testRegistry.onDRMAsset = { urlAsset, playbackID, options, rootDomain in
-                registeredExpectation.fulfill()
-                registeredAsset = urlAsset
-                XCTAssertEqual(playbackID, "abc")
-                XCTAssertEqual(options.playbackToken, "def")
-                XCTAssertEqual(options.drmToken, "ghi")
-                XCTAssertEqual(rootDomain, "mux.com")
-            }
+        let registeredExpectation = XCTestExpectation(description: "DRM asset should be registered")
+        testRegistry.onDRMAsset = { urlAsset, playbackID, options, rootDomain in
+            registeredExpectation.fulfill()
+            registeredAsset = urlAsset
+            XCTAssertEqual(playbackID, "abc")
+            XCTAssertEqual(options.playbackToken, "def")
+            XCTAssertEqual(options.drmToken, "ghi")
+            XCTAssertEqual(rootDomain, "mux.com")
+        }
 
-            let playerItem = AVPlayerItem(
-                playbackID: "abc",
-                playbackOptions: PlaybackOptions(
-                    playbackToken: "def",
-                    drmToken: "ghi"
-                )
-            )
+        let playerItem = AVPlayerItem(
+            playbackID: "abc",
+            playbackOptions: PlaybackOptions(
+                playbackToken: "def",
+                drmToken: "ghi"
+            ),
+            playerSDK: testSDK
+        )
 
-            wait(for: [registeredExpectation], timeout: 0)
+        wait(for: [registeredExpectation], timeout: 0)
 
-            XCTAssert(playerItem.asset === registeredAsset)
-//        }
+        XCTAssert(playerItem.asset === registeredAsset)
     }
 }

--- a/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
@@ -636,7 +636,7 @@ class FairPlaySessionManagerTests : XCTestCase {
             monitor: Monitor()
         )
 
-        PlayerSDK.$shared.withValue(testSDK) {
+//        PlayerSDK.$shared.withValue(testSDK) {
             var registeredAsset: AVURLAsset!
 
             let registeredExpectation = XCTestExpectation(description: "DRM asset should be registered")
@@ -660,6 +660,6 @@ class FairPlaySessionManagerTests : XCTestCase {
             wait(for: [registeredExpectation], timeout: 0)
 
             XCTAssert(playerItem.asset === registeredAsset)
-        }
+//        }
     }
 }

--- a/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
@@ -26,7 +26,7 @@ class MockKeyRequest : KeyRequest {
         }
     }
     
-    func makeContentKeyResponse(data: Data) -> AVContentKeyResponse {
+    func makeContentKeyResponse(fairPlayStreamingKeyResponseData data: Data) -> AVContentKeyResponse {
         // can't use the fairplay data in tests
         return AVContentKeyResponse(authorizationTokenData: "fake-token".data(using: .utf8)!)
     }
@@ -78,6 +78,11 @@ class MockKeyRequest : KeyRequest {
         return Data()
     }
 
+    func createPersistableKeyResponse(data: Data) -> AVContentKeyResponse {
+        fakeRequest.append((#function, [data]))
+        return AVContentKeyResponse(authorizationTokenData: "fake-persistable-token".data(using: .utf8)!)
+    }
+
     // MARK: verificaitons
     
     /// Verifies that the given method was called the given number of times
@@ -98,7 +103,7 @@ class MockKeyRequest : KeyRequest {
         }
     }
     
-    init(fakeIdentifier: String = "fake-identifier") {
+    init(fakeIdentifier: Any = "fake-identifier") {
         self.fakeIdentifier = fakeIdentifier
     }
 }

--- a/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
@@ -11,6 +11,7 @@ import AVFoundation
 
 /// Mock ``KeyRequest`` with some basic recording & verification
 class MockKeyRequest : KeyRequest {
+    
     // our fake 'request' just records calls and args
     typealias InnerRequest = [(String, [Any?])]
     
@@ -57,7 +58,7 @@ class MockKeyRequest : KeyRequest {
     }
     
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws {
-        fakeRequest.append(("respondByPersistableContentKeyRequestOnAnyOS", nil))
+        fakeRequest.append(("respondByPersistableContentKeyRequestOnAnyOS", []))
     }
     
     func persistableContentKey(fromKeyVendorResponse ckcData: Data, options: [String : Any]) {
@@ -65,6 +66,18 @@ class MockKeyRequest : KeyRequest {
         fakeRequest.append(("respondByPersistableContentKeyRequestOnAnyOS", args))
     }
     
+    func makeStreamingContentKeyRequestData(forApp appIdentifier: Data, contentIdentifier: Data?, options: [String : Any]?) async throws -> Data {
+        let args: [Any?] = [appIdentifier, contentIdentifier, options]
+        fakeRequest.append((#function, args))
+        return Data()
+    }
+    
+    func persistableContentKey(fromKeyVendorResponse: Data, options: [String : Any]?) throws -> Data {
+        let args: [Any?] = [fromKeyVendorResponse, options]
+        fakeRequest.append((#function, args))
+        return Data()
+    }
+
     // MARK: verificaitons
     
     /// Verifies that the given method was called the given number of times

--- a/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
@@ -56,6 +56,15 @@ class MockKeyRequest : KeyRequest {
         fakeRequest.append((funcName, args))
     }
     
+    func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws {
+        fakeRequest.append(("respondByPersistableContentKeyRequestOnAnyOS", nil))
+    }
+    
+    func persistableContentKey(fromKeyVendorResponse ckcData: Data, options: [String : Any]) {
+        let args: [Any] = [ckcData, options]
+        fakeRequest.append(("respondByPersistableContentKeyRequestOnAnyOS", args))
+    }
+    
     // MARK: verificaitons
     
     /// Verifies that the given method was called the given number of times

--- a/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
@@ -78,11 +78,6 @@ class MockKeyRequest : KeyRequest {
         return Data()
     }
 
-    func createPersistableKeyResponse(data: Data) -> AVContentKeyResponse {
-        fakeRequest.append((#function, [data]))
-        return AVContentKeyResponse(authorizationTokenData: "fake-persistable-token".data(using: .utf8)!)
-    }
-
     // MARK: verificaitons
     
     /// Verifies that the given method was called the given number of times

--- a/Tests/MuxPlayerSwift/Helpers/MockPersistedKeyStore.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockPersistedKeyStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import MuxPlayerSwift
+
+class MockPersistedKeyStore: PersistedKeyStore {
+
+    var persistedKeys: [String: Data] = [:]
+    var savedKeys: [(playbackID: String, identifier: String, data: Data)] = []
+    var updatedPhases: [(playbackID: String, phase: ExpirationPhase)] = []
+    var findError: Error?
+
+    func findPersistedContentKey(playbackID: String) async throws -> Data? {
+        if let findError { throw findError }
+        return persistedKeys[playbackID]
+    }
+
+    func savePersistedContentKey(playbackID: String, identifier: String, contentKeyData: Data) async throws {
+        savedKeys.append((playbackID, identifier, contentKeyData))
+    }
+
+    func updateExpirationPhase(playbackID: String, phase: ExpirationPhase) async {
+        updatedPhases.append((playbackID, phase))
+    }
+}

--- a/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
@@ -3,6 +3,23 @@ import Foundation
 @testable import MuxPlayerSwift
 
 class TestDRMAssetRegistry : DRMAssetRegistry {
+    func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
+    }
+    
+    func removeOfflineDownloadSession(playbackID: String) {
+    }
+    
+    func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async {
+    }
+    
+    func hasOfflineDRMConfig(playbackID: String) -> Bool {
+        return false
+    }
+    
+    func offlineKeyData(playbackID: String) -> Data? {
+        return nil
+    }
+    
     var onDRMAsset: ((AVURLAsset, String, MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, String) -> Void)?
     func addDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
         onDRMAsset?(urlAsset, playbackID, options, rootDomain)

--- a/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
@@ -12,7 +12,7 @@ class TestDRMAssetRegistry : DRMAssetRegistry {
     func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async {
     }
     
-    func hasOfflineDRMConfig(playbackID: String) -> Bool {
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool {
         return false
     }
     

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
@@ -14,6 +14,14 @@ import os
 /// sucess or failure as-configured
 class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCredentialClient {
     
+    func requestCertificate(playbackID: String) async throws -> Data {
+        return Data()
+    }
+    
+    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
+        return Data()
+    }
+    
     private let fakeCert: Data?
     private let fakeLicense: Data?
     private let failsWith: FairPlaySessionError!

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
@@ -26,7 +26,7 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
         )
     )
 
-    func requestCertificate(playbackID: String) async throws -> Data {
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data {
         if let fakeCert {
             return fakeCert
         } else if let certFailsWith {
@@ -36,7 +36,7 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
         }
     }
 
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data {
         if let fakeLicense {
             return fakeLicense
         } else if let licenseFailsWith {
@@ -46,26 +46,6 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
         }
     }
 
-
-    func requestCertificate(playbackID: String, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        if let fakeCert = fakeCert {
-            requestCompletion(Result.success(fakeCert))
-        } else if let certFailsWith {
-            requestCompletion(Result.failure(certFailsWith))
-        } else {
-            requestCompletion(Result.failure(.unexpected(message: "No fake cert or error configured")))
-        }
-    }
-
-    func requestLicense(spcData: Data, playbackID: String, offline _: Bool, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        if let fakeLicense = fakeLicense {
-            requestCompletion(Result.success(fakeLicense))
-        } else if let licenseFailsWith {
-            requestCompletion(Result.failure(licenseFailsWith))
-        } else {
-            requestCompletion(Result.failure(.unexpected(message: "No fake license or error configured")))
-        }
-    }
 
     convenience init(fakeCert: Data, fakeLicense: Data) {
         self.init(fakeCert: fakeCert, fakeLicense: fakeLicense, certFailsWith: nil, licenseFailsWith: nil)

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
@@ -13,10 +13,11 @@ import os
 /// This version does not interact with the network at all, it just signals
 /// sucess or failure as-configured
 class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCredentialClient {
-    
+
     private let fakeCert: Data?
     private let fakeLicense: Data?
-    private let failsWith: FairPlaySessionError!
+    private let certFailsWith: FairPlaySessionError?
+    private let licenseFailsWith: FairPlaySessionError?
 
     var logger: Logger = Logger(
         OSLog(
@@ -24,55 +25,73 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
             category: "CK"
         )
     )
-    
+
     func requestCertificate(playbackID: String) async throws -> Data {
         if let fakeCert {
             return fakeCert
+        } else if let certFailsWith {
+            throw certFailsWith
         } else {
-            throw failsWith
+            throw FairPlaySessionError.unexpected(message: "No fake cert or error configured")
         }
     }
-    
+
     func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
         if let fakeLicense {
             return fakeLicense
+        } else if let licenseFailsWith {
+            throw licenseFailsWith
         } else {
-            throw failsWith
+            throw FairPlaySessionError.unexpected(message: "No fake license or error configured")
         }
     }
-    
+
 
     func requestCertificate(playbackID: String, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
         if let fakeCert = fakeCert {
             requestCompletion(Result.success(fakeCert))
+        } else if let certFailsWith {
+            requestCompletion(Result.failure(certFailsWith))
         } else {
-            requestCompletion(Result.failure(failsWith))
+            requestCompletion(Result.failure(.unexpected(message: "No fake cert or error configured")))
         }
     }
-    
+
     func requestLicense(spcData: Data, playbackID: String, offline _: Bool, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
         if let fakeLicense = fakeLicense {
             requestCompletion(Result.success(fakeLicense))
+        } else if let licenseFailsWith {
+            requestCompletion(Result.failure(licenseFailsWith))
         } else {
-            requestCompletion(Result.failure(failsWith))
+            requestCompletion(Result.failure(.unexpected(message: "No fake license or error configured")))
         }
     }
-    
+
     convenience init(fakeCert: Data, fakeLicense: Data) {
-        self.init(fakeCert: fakeCert, fakeLicense: fakeLicense, failsWith: nil)
+        self.init(fakeCert: fakeCert, fakeLicense: fakeLicense, certFailsWith: nil, licenseFailsWith: nil)
     }
-    
+
     convenience init(failsWith: FairPlaySessionError) {
-        self.init(fakeCert: nil, fakeLicense: nil, failsWith: failsWith)
+        self.init(fakeCert: nil, fakeLicense: nil, certFailsWith: failsWith, licenseFailsWith: failsWith)
     }
-    
+
+    convenience init(certFailsWith: FairPlaySessionError) {
+        self.init(fakeCert: nil, fakeLicense: nil, certFailsWith: certFailsWith, licenseFailsWith: nil)
+    }
+
+    convenience init(fakeCert: Data, licenseFailsWith: FairPlaySessionError) {
+        self.init(fakeCert: fakeCert, fakeLicense: nil, certFailsWith: nil, licenseFailsWith: licenseFailsWith)
+    }
+
     private init(
         fakeCert: Data?,
         fakeLicense: Data?,
-        failsWith: FairPlaySessionError?
+        certFailsWith: FairPlaySessionError?,
+        licenseFailsWith: FairPlaySessionError?
     ) {
         self.fakeCert = fakeCert
         self.fakeLicense = fakeLicense
-        self.failsWith = failsWith
+        self.certFailsWith = certFailsWith
+        self.licenseFailsWith = licenseFailsWith
     }
 }

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
@@ -14,14 +14,6 @@ import os
 /// sucess or failure as-configured
 class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCredentialClient {
     
-    func requestCertificate(playbackID: String) async throws -> Data {
-        return Data()
-    }
-    
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
-        return Data()
-    }
-    
     private let fakeCert: Data?
     private let fakeLicense: Data?
     private let failsWith: FairPlaySessionError!
@@ -32,6 +24,23 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
             category: "CK"
         )
     )
+    
+    func requestCertificate(playbackID: String) async throws -> Data {
+        if let fakeCert {
+            return fakeCert
+        } else {
+            throw failsWith
+        }
+    }
+    
+    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
+        if let fakeLicense {
+            return fakeLicense
+        } else {
+            throw failsWith
+        }
+    }
+    
 
     func requestCertificate(playbackID: String, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
         if let fakeCert = fakeCert {

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
@@ -22,24 +22,16 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
         )
     )
 
-    func requestCertificate(playbackID: String, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        credentialClient.requestCertificate(playbackID: playbackID, completion: requestCompletion)
-    }
-
-    func requestLicense(spcData: Data, playbackID: String, offline: Bool, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        credentialClient.requestLicense(spcData: spcData, playbackID: playbackID, offline: offline, completion: requestCompletion)
-    }
-
     func addDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
         drmAssetRegistry.addDRMAsset(urlAsset, playbackID: playbackID, options: options, rootDomain: rootDomain)
     }
     
-    func requestCertificate(playbackID: String) async throws -> Data {
-        try await credentialClient.requestCertificate(playbackID: playbackID)
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data {
+        try await credentialClient.requestCertificate(playbackID: playbackID, offline: offline)
     }
 
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
-        try await credentialClient.requestLicence(spcData: spcData, playbackID: playbackID)
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data {
+        try await credentialClient.requestLicence(spcData: spcData, playbackID: playbackID, offline: offline)
     }
 
     func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
@@ -54,8 +46,8 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
         await drmAssetRegistry.addOfflinePlayDRMAsset(urlAsset, playbackID: playbackID, keyData: keyData)
     }
 
-    func hasOfflineDRMConfig(playbackID: String) -> Bool {
-        drmAssetRegistry.hasOfflineDRMConfig(playbackID: playbackID)
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool {
+        await drmAssetRegistry.hasOfflineDRMConfig(playbackID: playbackID)
     }
 
     func offlineKeyData(playbackID: String) -> Data? {

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
@@ -33,7 +33,35 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
     func addDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
         drmAssetRegistry.addDRMAsset(urlAsset, playbackID: playbackID, options: options, rootDomain: rootDomain)
     }
-   
+    
+    func requestCertificate(playbackID: String) async throws -> Data {
+        try await credentialClient.requestCertificate(playbackID: playbackID)
+    }
+
+    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
+        try await credentialClient.requestLicence(spcData: spcData, playbackID: playbackID)
+    }
+
+    func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
+        drmAssetRegistry.addOfflineDownloadDRMAsset(urlAsset, playbackID: playbackID, options: options, rootDomain: rootDomain)
+    }
+
+    func removeOfflineDownloadSession(playbackID: String) {
+        drmAssetRegistry.removeOfflineDownloadSession(playbackID: playbackID)
+    }
+
+    func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async {
+        await drmAssetRegistry.addOfflinePlayDRMAsset(urlAsset, playbackID: playbackID, keyData: keyData)
+    }
+
+    func hasOfflineDRMConfig(playbackID: String) -> Bool {
+        drmAssetRegistry.hasOfflineDRMConfig(playbackID: playbackID)
+    }
+
+    func offlineKeyData(playbackID: String) -> Data? {
+        drmAssetRegistry.offlineKeyData(playbackID: playbackID)
+    }
+    
     init(credentialClient: any FairPlayStreamingSessionCredentialClient,
          drmAssetRegistry: any DRMAssetRegistry) {
         self.credentialClient = credentialClient


### PR DESCRIPTION
Adds DRM key management for offline access.

There were a bunch of changes necessary to accommodate this:

* No more `@TaskLocal` PlayerSDK on debug builds
  * Since `DownloadMangaer` uses swift concurrency extensively, accessing `PlayerSDK.shared` via a `TaskLocal` will cause problems. We need a single `FairPlaySessionCredentialClient` instance to manage our requests, assets, and key sessions for the whole app
  * This change doesn't seem to break tests. If we want to make tests more ephemeral again, we should find another way. Maybe there's a simpler way to use Bindings without the task-local baggage

* License/app-cert request flows with Swift Concurrency. 
  * The DRM workflow for offline access must talk to `DownloadManager` often in order to hand off the keys it downloads. A completion handler-based async workflow would be horrible in this context, so I added `async` shims that can be called via from the Tasks in DownloadManager
  * As noted in the TODOs: The existing methods should be updated to use Swift Concurrency instead of completion handlers but I wanted to keep this PR's scope down as much as I could.
* Separate DRM path for persisted downloads
  * When you want a persistable key, you have to start a new flow from `AVContentKeySessionDelegate:didProvide AVContentKeyRequest`.
* Updates for expiration-date handling
  * Our drm tokens have a known format, including expiration periods. There is no system-provided way to query the expiration times of an offline key, so we estimate them from the values in the `drm_token`. This estimate should be very close, since the licenses expire some number of seconds after calling `license/` regardless of when the token was created)
  * FairPlay may provide a way to query a KSM for a CKC's expiration time, but 1) this isn't exposed from our DRM vendor afaik and 2) you can't do that offline anyway
 * Several new methods on `DRMAssetRegistry`. The overall process of saving and managing the results of the DRM key exchange required `DRMAssetRegistry` to be much more interactive, so several methods have been added to keep track of offline downloads
 * One `ContenKeySession` per download.  This is required due to a behavior quirk of `AVContentKeySession`. An AVContentKeySession will only go through a download process once per key identifier (coupled to playabckID in Mux Video). If you delete and re-download the same protected asset twice, the ContentKeySession will erroneously assume you still have the key (it has no way of knowing when you delete keys)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it substantially changes FairPlay DRM key request/response handling, adds persisted-key storage, and alters offline download/playback behavior and state transitions.
> 
> **Overview**
> Adds **offline DRM key management** for FairPlay downloads: the content-key delegate now supports `AVPersistableContentKeyRequest`, persists/updates keys via a `PersistedKeyStore`, and uses Swift concurrency with explicit error propagation.
> 
> Updates the offline subsystem to **store persisted CKC keys on disk**, maintain per-asset DRM expiration metadata (new `DRMTokenClaims`, `ExpirationPhase`, and `StoredAsset.isExpired()`), and return a new `.expired` status when licenses are no longer valid.
> 
> Refactors the FairPlay session manager to async `requestCertificate`/`requestLicence`, splits DRM config tracking for online vs offline, and creates **one `AVContentKeySession` per download** to ensure re-downloads trigger fresh key requests; related tests and the example app UI are updated (renaming the example download manager, adding an *Expired* state, and retry logic that removes then re-downloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2aabfbd88e4cb96fcfc397022bfb9f053186cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->