### PR TITLE
requestLicense/requestCertificate async by default

### DIFF
--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -36,9 +36,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         didProvide keyRequest: AVContentKeyRequest
     ) {
         logger.trace("didProvide AVContentKeyRequest")
-        handleContentKeyRequest(
-            request: DefaultKeyRequest(wrapping: keyRequest)
-        )
+        Task {
+            do {
+                try await handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+            } catch {
+                keyRequest.processContentKeyResponseError(error)
+            }
+        }
     }
     
     func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVPersistableContentKeyRequest) {
@@ -73,7 +77,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         didProvideRenewingContentKeyRequest keyRequest: AVContentKeyRequest
     ) {
         logger.trace("didProvide didProvideRenewingContentKeyRequest")
-        handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+        Task {
+            do {
+                try await handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+            } catch {
+                keyRequest.processContentKeyResponseError(error)
+            }
+        }
     }
     
     func contentKeySession(
@@ -261,7 +271,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         )
     }
     
-    func handleContentKeyRequest(request: any KeyRequest) {
+    func handleContentKeyRequest(request: any KeyRequest) async throws {
         logger.debug(
             "Called \(#function)"
         )
@@ -305,113 +315,27 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
                 //  .. although using an 'offline' drm_token for playing an asset is technically not supported
             }
         }
-
-        // get app cert
-        sessionManager.requestCertificate(
-            playbackID: playbackID,
-            completion: { [weak self] result in
-                guard let self else {
-                    PlayerSDK.shared.diagnosticsLogger.debug(
-                        "Content key request completed: missing session delegate"
-                    )
-                    return
-                }
-
-                let applicationCertificate: Data
-                do {
-                    applicationCertificate = try result.get()
-                } catch {
-                    request.processContentKeyResponseError(
-                        error
-                    )
-                    return
-                }
-
-                handleApplicationCertificate(
-                    applicationCertificate,
-                    contentIdentifier: utfEncodedRequestIdentifierString,
-                    playbackID: playbackID,
-                    request: request)
-            }
-        )
-    }
-
-    func handleApplicationCertificate(
-        _ applicationCertificate: Data,
-        contentIdentifier utfEncodedRequestIdentifierString: Data,
-        playbackID: String,
-        request: any KeyRequest
-    ) {
-        // exchange app cert for SPC using KeyRequest to give to CDM
-        request.makeStreamingContentKeyRequestData(
-            forApp: applicationCertificate,
+        
+        // If we're not playing offline, do the handshake for an online key request
+        let certData = try await sessionManager.requestCertificate(playbackID: playbackID)
+        let spcData = try await request.makeStreamingContentKeyRequestData(
+            forApp: certData,
             contentIdentifier: utfEncodedRequestIdentifierString,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
-        ) { [weak self] spcData, error in
-            guard let self = self else {
-                PlayerSDK.shared.diagnosticsLogger.debug(
-                    "Content key request completed: missing session delegate"
-                )
-                return
-            }
-            
-            guard let spcData = spcData else {
-                request.processContentKeyResponseError(
-                    error ?? FairPlaySessionError.unexpected(message: "no SPC")
-                )
-                return
-            }
-            
-            // exchange SPC for CKC
-            handleSpcObtainedFromCDMForOnlineKey(
-                spcData: spcData,
-                playbackID: playbackID,
-                request: request
-            )
-        }
-    }
-    
-    func handleSpcObtainedFromCDMForOnlineKey(
-        spcData: Data,
-        playbackID: String,
-        request: any KeyRequest
-    ) {
-        guard let sessionManager = self.sessionManager else {
-            logger.debug("Missing Session Manager")
-            return
-        }
+        )
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
         
-        sessionManager.requestLicense(
-            spcData: spcData,
-            playbackID: playbackID,
-            offline: false
-        ) { [weak self] result in
-            guard let self else {
-                return
-            }
-
-            let ckcData: Data
-            do {
-                ckcData = try result.get()
-            } catch {
-                request.processContentKeyResponseError(
-                    error
-                )
-                return
-            }
-
-            logger.debug("Submitting CKC to system")
-            // Send CKC to CDM/wherever else so we can finally play our content
-            let keyResponse = request.makeContentKeyResponse(
-                fairPlayStreamingKeyResponseData: ckcData
-            )
-            request.processContentKeyResponse(
-                keyResponse
-            )
-            logger.debug("Protected content now available for processing")
-            // Done! no further interaction is required from us to play.
-        }
-    }
+        // Send CKC to CDM/ContentKeySession so we can finally play our content
+        logger.debug("Submitting CKC to system")
+        let keyResponse = request.makeContentKeyResponse(
+            fairPlayStreamingKeyResponseData: ckcData
+        )
+        request.processContentKeyResponse(
+            keyResponse
+        )
+        logger.debug("Protected content now available for processing")
+        // Done! no further interaction is required from us to play.
+   }
 }
 
 // Wraps a generic request for a key and delegates calls to it

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -305,7 +305,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
         
         // Check for offline - if this is for offline, we trigger the persistable content key flow
-        if sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
+        if await sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
             do {
                 try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
                 // no more processing for this key request. we'll get a delegate call with a persistable key request next

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -251,13 +251,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
 
         // No content key already? Try to get one
-        let appCertData = try await sessionManager.requestCertificate(playbackID: playbackID)
+        let appCertData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: true)
         let spcData = try await request.makeStreamingContentKeyRequestData(
             forApp: appCertData,
             contentIdentifier: utfEncodedRequestIdentifierString,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
         )
-        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: true)
         
         let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
         try await persistedKeyStore.savePersistedContentKey(
@@ -317,13 +317,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         }
         
         // If we're not playing offline, do the handshake for an online key request
-        let certData = try await sessionManager.requestCertificate(playbackID: playbackID)
+        let certData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: false)
         let spcData = try await request.makeStreamingContentKeyRequestData(
             forApp: certData,
             contentIdentifier: utfEncodedRequestIdentifierString,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
         )
-        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID)
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: false)
         
         // Send CKC to CDM/ContentKeySession so we can finally play our content
         logger.debug("Submitting CKC to system")

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -17,9 +17,9 @@ import os
 protocol FairPlayStreamingSessionCredentialClient: AnyObject {
     // MARK: Requesting licenses and certs
 
-    func requestCertificate(playbackID: String) async throws -> Data
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data
 
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data
 
     var logger: Logger { get set }
 }
@@ -129,31 +129,32 @@ class DefaultFairPlayStreamingSessionManager<
 
     private let urlSession: URLSession
     
-    private func offlineDRMConfigOnQueue(for playbackID: String) async -> DRMConfig? {
+    private func drmConfigOnQueue(for playbackID: String, offline: Bool) async -> DRMConfig? {
         return await withCheckedContinuation { continuation in
             queue.async { [logger, weak self] in
                 guard let self else {
-                    logger.warning("looked up offline DRMConfig after cleanup")
+                    logger.warning("looked up DRMConfig after cleanup")
                     continuation.resume(returning: nil)
                     return
                 }
-                continuation.resume(returning: offlineDownloadKeyLookup[playbackID])
+                let lookup = offline ? offlineDownloadKeyLookup : onlineKeyConfigLookup
+                continuation.resume(returning: lookup[playbackID])
             }
         }
     }
-    
+
     // MARK: Requesting licenses and certs
 
-    func requestCertificate(playbackID: String) async throws -> Data {
-        guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data {
+        guard let config = await drmConfigOnQueue(for: playbackID, offline: offline) else {
             throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
         }
 
         return try await requestCertificateInner(playbackID: playbackID, drmConfig: config)
     }
 
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
-        guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data {
+        guard let config = await drmConfigOnQueue(for: playbackID, offline: offline) else {
             throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
         }
 

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -143,53 +143,28 @@ class DefaultFairPlayStreamingSessionManager<
     }
     
     // MARK: Requesting licenses and certs
-    
+
     func requestCertificate(playbackID: String) async throws -> Data {
         guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
             throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
         }
-        
-        // TODO: (future maintenance) request should be async by default, not completion handlers by default
-        return try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self = self else {
-                continuation.resume(throwing:
-                    FairPlaySessionError.unexpected(message: "SessionManager terminated while fetching app cert")
-                )
-                return
-            }
-            
-            self.requestCertificateInner(playbackID: playbackID, drmConfig: config) { continuation.resume(with: $0) }
-        }
+
+        return try await requestCertificateInner(playbackID: playbackID, drmConfig: config)
     }
-    
+
     func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
         guard let config = await offlineDRMConfigOnQueue(for: playbackID) else {
             throw FairPlaySessionError.unexpected(message: "No DRM config tracked for playbackID: \(playbackID)")
         }
-        
-        // TODO: (future maintenance) request should be async by default, not completion handlers by default
-        return try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self else {
-                continuation.resume(throwing:
-                    FairPlaySessionError.unexpected(message: "SessionManager terminated while fetching license")
-                )
-                return
-            }
-            
-            self.requestLicenseInner(
-                spcData: spcData,
-                playbackID: playbackID,
-                drmConfig: config
-            ) { continuation.resume(with: $0) }
-        }
+
+        return try await requestLicenseInner(spcData: spcData, playbackID: playbackID, drmConfig: config)
     }
-    
+
     /// Requests the App Certificate for a playback id
     private func requestCertificateInner(
         playbackID: String,
-        drmConfig config: DRMConfig,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
+        drmConfig config: DRMConfig
+    ) async throws -> Data {
         let rootDomain = config.rootDomain
         let drmToken = config.options.drmToken
 
@@ -204,16 +179,11 @@ class DefaultFairPlayStreamingSessionManager<
             let error = FairPlaySessionError.unexpected(
                 message: "Invalid certificate domain"
             )
-            requestCompletion(
-                Result.failure(
-                    error
-                )
-            )
             errorDispatcher.dispatchApplicationCertificateRequestError(
                 error: error,
                 playbackID: playbackID
             )
-            return
+            throw error
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -222,102 +192,81 @@ class DefaultFairPlayStreamingSessionManager<
             "Requesting application certificate from \(url, privacy: .auto(mask: .hash))"
         )
 
-        let dataTask = urlSession.dataTask(with: request) { [requestCompletion] data, response, error in
-            self.logger.debug(
-                "Application certificate request completed"
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            logger.debug(
+                "Application certificate request failed with error: \(error.localizedDescription)"
             )
+            let fpsError = FairPlaySessionError.because(cause: error)
+            errorDispatcher.dispatchApplicationCertificateRequestError(
+                error: fpsError,
+                playbackID: playbackID
+            )
+            throw fpsError
+        }
 
-            var responseCode: Int? = nil
-            if let httpResponse = response as? HTTPURLResponse {
-                responseCode = httpResponse.statusCode
-                self.logger.debug(
-                    "Application certificate response code: \(httpResponse.statusCode)"
-                )
-                self.logger.debug(
-                    "Application certificate response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
-                )
-                if let data, let utfData = String(
-                    data: data,
-                    encoding: .utf8
-                ) {
-                    self.logger.debug(
-                        "Application certificate data: \(utfData)"
-                    )
-                }
+        logger.debug(
+            "Application certificate request completed"
+        )
 
-            }
-            // error case: I/O failed
-            if let error = error {
-                self.logger.debug(
-                    "Application certificate request failed with error: \(error.localizedDescription)"
+        if let httpResponse = response as? HTTPURLResponse {
+            logger.debug(
+                "Application certificate response code: \(httpResponse.statusCode)"
+            )
+            logger.debug(
+                "Application certificate response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
+            )
+            if let utfData = String(data: data, encoding: .utf8) {
+                logger.debug(
+                    "Application certificate data: \(utfData)"
                 )
-                let error = FairPlaySessionError.because(cause: error)
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchApplicationCertificateRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
             }
+
             // error case: I/O finished with non-successful response
-            guard responseCode == 200 else {
-                self.logger.debug(
-                    "Application certificate request failed with response code: \(String(describing: responseCode))"
+            guard httpResponse.statusCode == 200 else {
+                logger.debug(
+                    "Application certificate request failed with response code: \(httpResponse.statusCode)"
                 )
                 let error = FairPlaySessionError.httpFailed(
-                    responseStatusCode: responseCode ?? 0
+                    responseStatusCode: httpResponse.statusCode
                 )
-                requestCompletion(
-                    Result.failure(
-                        error
-                    )
-                )
-                self.errorDispatcher.dispatchApplicationCertificateRequestError(
+                errorDispatcher.dispatchApplicationCertificateRequestError(
                     error: error,
                     playbackID: playbackID
                 )
-                return
+                throw error
             }
-            // this edge case (200 with invalid data) is possible from our DRM vendor
-            guard let data = data,
-                  data.count > 0 else {
-                let error = FairPlaySessionError.unexpected(
-                    message: "No cert data with 200 OK response"
-                )
-                self.logger.debug(
-                    "Application certificate request completed with missing data and response code \(responseCode.debugDescription)"
-                )
-                requestCompletion(
-                    Result.failure(
-                        error
-                    )
-                )
-                self.errorDispatcher.dispatchApplicationCertificateRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
-            }
-            
-            self.logger.debug("Application certificate response data:\(data.base64EncodedString(), privacy: .auto(mask: .hash))")
-
-            requestCompletion(Result.success(data))
         }
-        
-        dataTask.resume()
+
+        // this edge case (200 with invalid data) is possible from our DRM vendor
+        guard data.count > 0 else {
+            let error = FairPlaySessionError.unexpected(
+                message: "No cert data with 200 OK response"
+            )
+            logger.debug(
+                "Application certificate request completed with missing data"
+            )
+            errorDispatcher.dispatchApplicationCertificateRequestError(
+                error: error,
+                playbackID: playbackID
+            )
+            throw error
+        }
+
+        logger.debug("Application certificate response data:\(data.base64EncodedString(), privacy: .auto(mask: .hash))")
+
+        return data
     }
-    
+
     /// Requests a license to play based on the given SPC data
-    /// - parameter offline - Not currently used, may not ever be used in short-term, maybe delete?
     private func requestLicenseInner(
         spcData: Data,
         playbackID: String,
-        drmConfig config: DRMConfig,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
-
+        drmConfig config: DRMConfig
+    ) async throws -> Data {
         let drmToken = config.options.drmToken
         let rootDomain = config.rootDomain
 
@@ -329,97 +278,75 @@ class DefaultFairPlayStreamingSessionManager<
             let error = FairPlaySessionError.unexpected(
                 message: "Invalid FairPlay license domain"
             )
-            requestCompletion(
-                Result.failure(
-                    error
-                )
-            )
             errorDispatcher.dispatchLicenseRequestError(
                 error: error,
                 playbackID: playbackID
             )
-            return
+            throw error
         }
 
         var request = URLRequest(url: url)
-        
-        // POST body is the SPC bytes
         request.httpMethod = "POST"
         request.httpBody = spcData
-        
-        // QUERY PARAMS
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         request.setValue(String(format: "%lu", request.httpBody?.count ?? 0), forHTTPHeaderField: "Content-Length")
         logger.debug("Sending License/CKC Request to: \(request.url?.absoluteString ?? "nil")")
         logger.debug("\t with header fields: \(String(describing: request.allHTTPHeaderFields))")
 
-        let task = urlSession.dataTask(with: request) { [requestCompletion] data, response, error in
-            // error case: I/O failed
-            if let error = error {
-                self.logger.debug(
-                    "URL Session Task Failed: \(error.localizedDescription)"
-                )
-                let error = FairPlaySessionError.because(cause: error)
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchLicenseRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
-            }
-            
-            var responseCode: Int? = nil
-            if let httpResponse = response as? HTTPURLResponse {
-                responseCode = httpResponse.statusCode
-                self.logger.debug(
-                    "License response code: \(httpResponse.statusCode)"
-                )
-                self.logger.debug(
-                    "License response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
-                )
-            }
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            logger.debug(
+                "URL Session Task Failed: \(error.localizedDescription)"
+            )
+            let fpsError = FairPlaySessionError.because(cause: error)
+            errorDispatcher.dispatchLicenseRequestError(
+                error: fpsError,
+                playbackID: playbackID
+            )
+            throw fpsError
+        }
+
+        if let httpResponse = response as? HTTPURLResponse {
+            logger.debug(
+                "License response code: \(httpResponse.statusCode)"
+            )
+            logger.debug(
+                "License response headers: \(httpResponse.allHeaderFields, privacy: .auto(mask: .hash))"
+            )
+
             // error case: I/O finished with non-successful response
-            guard responseCode == 200 else {
-                self.logger.debug(
-                    "CKC request failed: \(String(describing: responseCode))"
+            guard httpResponse.statusCode == 200 else {
+                logger.debug(
+                    "CKC request failed: \(httpResponse.statusCode)"
                 )
                 let error = FairPlaySessionError.httpFailed(
-                    responseStatusCode: responseCode ?? 0
+                    responseStatusCode: httpResponse.statusCode
                 )
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchLicenseRequestError(
+                errorDispatcher.dispatchLicenseRequestError(
                     error: error,
                     playbackID: playbackID
                 )
-
-                return
+                throw error
             }
-            // strange edge case: 200 with no response body
-            //  this happened because of a client-side encoding difference causing an error
-            //  with our drm vendor and probably shouldn't be reachable, but lets not crash
-            guard let data = data,
-                  data.count > 0
-            else {
-                let error = FairPlaySessionError.unexpected(message: "No license data with 200 response")
-                self.logger.debug("No CKC data despite server returning success")
-                requestCompletion(Result.failure(
-                    error
-                ))
-                self.errorDispatcher.dispatchLicenseRequestError(
-                    error: error,
-                    playbackID: playbackID
-                )
-                return
-            }
-            
-            let ckcData = data
-            requestCompletion(Result.success(ckcData))
         }
-        task.resume()
+
+        // strange edge case: 200 with no response body
+        //  this happened because of a client-side encoding difference causing an error
+        //  with our drm vendor and probably shouldn't be reachable, but lets not crash
+        guard data.count > 0 else {
+            let error = FairPlaySessionError.unexpected(message: "No license data with 200 response")
+            logger.debug("No CKC data despite server returning success")
+            errorDispatcher.dispatchLicenseRequestError(
+                error: error,
+                playbackID: playbackID
+            )
+            throw error
+        }
+
+        return data
     }
     
     // MARK: registering assets

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -17,22 +17,8 @@ import os
 protocol FairPlayStreamingSessionCredentialClient: AnyObject {
     // MARK: Requesting licenses and certs
 
-    // Requests the App Certificate for a playback id
-    func requestCertificate(
-        playbackID: String,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    )
-    // Requests a license to play based on the given SPC data
-    // - parameter offline - Not currently used, may not ever be used in short-term, maybe delete?
-    func requestLicense(
-        spcData: Data,
-        playbackID: String,
-        offline _: Bool,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    )
-    
     func requestCertificate(playbackID: String) async throws -> Data
-    
+
     func requestLicence(spcData: Data, playbackID: String) async throws -> Data
 
     var logger: Logger { get set }
@@ -196,50 +182,6 @@ class DefaultFairPlayStreamingSessionManager<
                 drmConfig: config
             ) { continuation.resume(with: $0) }
         }
-    }
-    
-    func requestCertificate(
-        playbackID: String,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
-        guard let config = onlineKeyConfigLookup[playbackID] else {
-            logger.debug(
-                "No registered DRM configuration for playbackID \(playbackID)."
-            )
-            requestCompletion(
-                .failure(
-                    FairPlaySessionError.unexpected(
-                        message: "No registered DRM configuration for playbackID \(playbackID)"
-                    )
-                )
-            )
-            return
-        }
-        
-        requestCertificateInner(playbackID: playbackID, drmConfig: config, completion: requestCompletion)
-    }
-
-    func requestLicense(
-        spcData: Data,
-        playbackID: String,
-        offline: Bool,
-        completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void
-    ) {
-        guard let config = onlineKeyConfigLookup[playbackID] else {
-            logger.debug(
-                "No registered DRM configuration for playbackID \(playbackID)."
-            )
-            requestCompletion(
-                .failure(
-                    FairPlaySessionError.unexpected(
-                        message: "No registered DRM configuration for playbackID \(playbackID)"
-                    )
-                )
-            )
-            return
-        }
-        
-        requestLicenseInner(spcData: spcData, playbackID: playbackID, drmConfig: config, completion: requestCompletion)
     }
     
     /// Requests the App Certificate for a playback id

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -31,7 +31,7 @@ protocol DRMAssetRegistry {
     func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String)
     func removeOfflineDownloadSession(playbackID: String)
     func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async
-    func hasOfflineDRMConfig(playbackID: String) -> Bool
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool
     func offlineKeyData(playbackID: String) -> Data?
 }
 
@@ -409,9 +409,18 @@ class DefaultFairPlayStreamingSessionManager<
         self.contentKeySession.addContentKeyRecipient(urlAsset)
     }
     
-    func hasOfflineDRMConfig(playbackID: String) -> Bool {
-        // called from ContentKeySessionDelegate, is definitely on .queue
-        return offlinePlayLookup[playbackID] != nil || offlineDownloadKeyLookup[playbackID] != nil
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            queue.async { [logger, weak self] in
+                guard let self else {
+                    logger.warning("looked up offline DRM config after cleanup")
+                    continuation.resume(returning: false)
+                    return
+                }
+                let result = offlinePlayLookup[playbackID] != nil || offlineDownloadKeyLookup[playbackID] != nil
+                continuation.resume(returning: result)
+            }
+        }
     }
     
     func offlineKeyData(playbackID: String) -> Data? {

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -92,104 +92,98 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertEqual(fakePlaybackID, foundPlaybackID)
     }
     
-    func testKeyRequestNoPlaybackId() throws {
+    func testKeyRequestNoPlaybackId() async {
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrlIncorrect()
         )
-        
-        contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-        
+
+        do {
+            try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+        } catch {
+            // error is acceptable here too
+        }
+
         XCTAssertTrue(
             mockRequest.verifyWasCalled(
                 funcName: "processContentKeyResponseError"
             )
         )
         XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "makeStreamingContentKeyRequestData")
+            mockRequest.verifyNotCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
         )
     }
-    
-    func testKeyRequestCertError() throws {
-        setUpForFailure(error: .unexpected(message: "fake error"))
+
+    func testKeyRequestCertError() async {
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                certFailsWith: .unexpected(message: "cert error")
+            )
+        )
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
-        
-        contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-        XCTAssertTrue(
-            mockRequest.verifyWasCalled(
-                funcName: "processContentKeyResponseError"
+
+        do {
+            try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(
+                    funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+                )
+            )
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
+    }
+
+    func testKeyRequestLicenseError() async {
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                fakeCert: "fake-cert".data(using: .utf8)!,
+                licenseFailsWith: .unexpected(message: "license error")
             )
         )
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "makeStreamingContentKeyRequestData")
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
+
+        do {
+            try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Should have gotten past cert and SPC stages
+            XCTAssertTrue(
+                mockRequest.verifyWasCalled(
+                    funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+                )
+            )
+            // But should not have processed a response
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+            )
+        }
     }
-    
-    func testKeyRequestHappyPath() throws {
+
+    func testKeyRequestHappyPath() async throws {
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(
                 fakePlaybackID: "fake-playback"
             )
         )
-        testDRMAssetRegistry.addDRMAsset(
-            AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
-            playbackID: "fake-playback",
-            options: .init(playbackToken: "playback-token", drmToken: "drm-token"),
-            rootDomain: "example.com")
 
-        contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-        
+        try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+
         XCTAssertTrue(
             mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
         )
-        XCTAssertTrue(
-            mockRequest.verifyWasCalled(funcName: "makeStreamingContentKeyRequestData")
-        )
-    }
-    
-    func testSPCForCKCFailedLicense() throws {
-        setUpForFailure(error: .unexpected(message: "fake error"))
-        let mockRequest = MockKeyRequest(
-            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
-        )
-        
-        contentKeySessionDelegate.handleSpcObtainedFromCDMForOnlineKey(
-            spcData: "fake-spc-data".data(using: .utf8)!,
-            playbackID: "fake-playback",
-            request: mockRequest
-        )
-        
         XCTAssertTrue(
             mockRequest.verifyWasCalled(
-                funcName: "processContentKeyResponseError"
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
             )
-        )
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
-        )
-    }
-    
-    func testSPCForCKCHappyPath() throws {
-        let mockRequest = MockKeyRequest(
-            fakeIdentifier: makeFakeSkdUrl(
-                fakePlaybackID: "fake-playback"
-            )
-        )
-        testDRMAssetRegistry.addDRMAsset(
-            AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
-            playbackID: "fake-playback",
-            options: .init(playbackToken: "playback-token", drmToken: "drm-token"),
-            rootDomain: "example.com")
-
-        contentKeySessionDelegate.handleSpcObtainedFromCDMForOnlineKey(
-            spcData: "fake-spc-data".data(using: .utf8)!,
-            playbackID: "fake-playback",
-            request: mockRequest
-        )
-
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
         )
         XCTAssertTrue(
             mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")

--- a/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
@@ -109,7 +109,7 @@ class FairPlaySessionManagerTests : XCTestCase {
             return (HTTPURLResponse(), nil)
         }
 
-        _ = try? await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+        _ = try? await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
 
         let urlComponents = URLComponents(string: urlRequest.url!.absoluteString)!
         XCTAssertNotNil(urlComponents.queryItems)
@@ -156,7 +156,7 @@ class FairPlaySessionManagerTests : XCTestCase {
             return (response, "fake ckc data".data(using: .utf8))
         }
 
-        _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+        _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
 
         let urlComponents = URLComponents(string: urlRequest.url!.absoluteString)!
         XCTAssertNotNil(urlComponents.queryItems)
@@ -212,7 +212,7 @@ class FairPlaySessionManagerTests : XCTestCase {
             return (response, fakeAppCert)
         }
 
-        let result = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+        let result = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
         XCTAssertEqual(result, fakeAppCert)
     }
 
@@ -242,7 +242,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         }
 
         do {
-            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
             XCTFail("failure should have been reported")
         } catch let fpsError as FairPlaySessionError {
             if case .httpFailed(let code) = fpsError {
@@ -270,7 +270,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         }
 
         do {
-            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
             XCTFail("failure should have been reported")
         } catch let fpsError as FairPlaySessionError {
             guard case .because(_) = fpsError else {
@@ -303,7 +303,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         }
 
         do {
-            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId, offline: true)
             XCTFail("failure should have been reported")
         } catch let fpsError as FairPlaySessionError {
             guard case .unexpected(let message) = fpsError else {
@@ -338,7 +338,7 @@ class FairPlaySessionManagerTests : XCTestCase {
             return (response, fakeLicense)
         }
 
-        let result = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+        let result = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
         XCTAssertEqual(result, fakeLicense)
     }
 
@@ -369,7 +369,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         }
 
         do {
-            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
             XCTFail("failure should have been reported")
         } catch let fpsError as FairPlaySessionError {
             if case .httpFailed(let code) = fpsError {
@@ -398,7 +398,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         }
 
         do {
-            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
             XCTFail("failure should have been reported")
         } catch let fpsError as FairPlaySessionError {
             guard case .because(_) = fpsError else {
@@ -432,7 +432,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         }
 
         do {
-            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId, offline: true)
             XCTFail("failure should have been reported")
         } catch let fpsError as FairPlaySessionError {
             guard case .unexpected(let message) = fpsError else {

--- a/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/FairPlaySessionManagerTests.swift
@@ -15,10 +15,6 @@ class FairPlaySessionManagerTests : XCTestCase {
     
     // object under test
     private var sessionManager: FairPlayStreamingSessionManager!
-    
-    // FairPlayStreamingSessionManager expects most of these calls to come from AVContentKeySession,
-    // so send them from this queue to avoid memory corruption in the DRM config lookup
-    private var targetQueue: DispatchQueue!
 
     override func setUp() {
         super.setUp()
@@ -26,7 +22,6 @@ class FairPlaySessionManagerTests : XCTestCase {
         mockURLSessionConfig.protocolClasses = [MockURLProtocol.self]
         let session = TestContentKeySession()
         let queue = DispatchQueue(label: "test target queue")
-        self.targetQueue = queue
         let defaultFairPlaySessionManager = DefaultFairPlayStreamingSessionManager(
             contentKeySession: session,
             errorDispatcher: Monitor(),
@@ -95,13 +90,13 @@ class FairPlaySessionManagerTests : XCTestCase {
         )
     }
     
-    func testAppCertificateRequestBody() throws {
+    func testAppCertificateRequestBody() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
@@ -113,44 +108,35 @@ class FairPlaySessionManagerTests : XCTestCase {
             // response is not part of this test
             return (HTTPURLResponse(), nil)
         }
-        
-        let requestEnds = XCTestExpectation(description: "request ends")
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                // we recorded the request so we should be ok
-                requestEnds.fulfill()
-            }
-        }
-        wait(for: [requestEnds])
-        
+
+        _ = try? await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+
         let urlComponents = URLComponents(string: urlRequest.url!.absoluteString)!
         XCTAssertNotNil(urlComponents.queryItems)
         XCTAssert(urlComponents.queryItems!.count > 0)
-        
+
         let tokenParam = urlComponents.queryItems!.first { it in it.name == "token"}
         let playbackID = urlRequest.url!.lastPathComponent
 
         XCTAssertNotNil(tokenParam)
         XCTAssertEqual(tokenParam?.name, "token")
         XCTAssertEqual(tokenParam?.value, fakeDrmToken)
-        
+
         XCTAssertEqual(playbackID, fakePlaybackId)
 
         XCTAssertEqual(urlRequest.httpMethod, "GET")
         // note: url tested using testMakeAppCertificateURL
     }
     
-    func testLicenseRequestBody() throws {
+    func testLicenseRequestBody() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         // real SPC's are opaque binary to us, the fake one can be whatever
         let fakeSpcData = "fake-SPC-binary-data".data(using: .utf8)!
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
@@ -159,7 +145,7 @@ class FairPlaySessionManagerTests : XCTestCase {
         var urlRequest: URLRequest!
         MockURLProtocol.requestHandler = { request in
             urlRequest = request
-            
+
             // response is not part of this test
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -169,24 +155,13 @@ class FairPlaySessionManagerTests : XCTestCase {
             )!
             return (response, "fake ckc data".data(using: .utf8))
         }
-        
-        let requestEnds = XCTestExpectation(description: "request ends")
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                // we recorded the request so we should be ok
-                requestEnds.fulfill()
-            }
-        }
-        wait(for: [requestEnds])
-        
+
+        _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+
         let urlComponents = URLComponents(string: urlRequest.url!.absoluteString)!
         XCTAssertNotNil(urlComponents.queryItems)
         XCTAssert(urlComponents.queryItems!.count > 0)
-        
+
         let tokenParam = urlComponents.queryItems!.first { it in it.name == "token"}
         let playbackID = urlRequest.url!.lastPathComponent
 
@@ -195,13 +170,13 @@ class FairPlaySessionManagerTests : XCTestCase {
         XCTAssertEqual(tokenParam?.value, fakeDrmToken)
 
         XCTAssertEqual(playbackID, fakePlaybackId)
-        
+
         // unfortunately we can't test the body for some reason, it's always nil even
         //  when intercepting with URLProtocol
         //XCTAssertEqual(urlRequest.httpBody, fakeSpcData)
-        
+
         XCTAssertEqual(urlRequest.httpMethod, "POST")
-        
+
         let headers = urlRequest.allHTTPHeaderFields
         guard let headers = headers, headers.count > 0 else {
             XCTFail("Request for License/CKC must have length and content type")
@@ -213,21 +188,20 @@ class FairPlaySessionManagerTests : XCTestCase {
         XCTAssertEqual(contentTypeHeader, "application/octet-stream")
     }
 
-    func testRequestCertificateSuccess() throws {
+    func testRequestCertificateSuccess() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         // real app certs are opaque binary to us, the fake one can be whatever
-        let fakeAppCert = "fake-application-cert-binary-data".data(using: .utf8)
-        
-        sessionManager.addDRMAsset(
+        let fakeAppCert = "fake-application-cert-binary-data".data(using: .utf8)!
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestCompleted = XCTestExpectation(description: "request certificate completion")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -235,37 +209,26 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, fakeAppCert)
         }
-        
-        var requestResult: Result<Data, FairPlaySessionError>!
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                requestResult = result
-                requestCompleted.fulfill()
-            }
-        }
-        wait(for: [requestCompleted])
-        XCTAssertEqual(try requestResult.get(), fakeAppCert)
+
+        let result = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+        XCTAssertEqual(result, fakeAppCert)
     }
-    
-    func testRequestCertificateHttpError() throws {
+
+    func testRequestCertificateHttpError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         let fakeHTTPStatus = 500 // all codes are handled the same way, by failing
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -273,107 +236,62 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
-            // failed requests proxied from our drm vendor have response bodies with
-            //   base64 text, which we should treat as opaque (not parse or decode),
-            //   since can't do anything with them and Cast logs them on the backend
             let errorBody = "failed request source text"
-            let errorData = errorBody.data(using: .utf8) // crashes if processed probably
-            return (
-                response,
-                errorData
-            )
+            let errorData = errorBody.data(using: .utf8)
+            return (response, errorData)
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
 
+        do {
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            if case .httpFailed(let code) = fpsError {
+                XCTAssertEqual(code, fakeHTTPStatus)
+            } else {
+                XCTFail("HTTP failure not reported with .httpFailed()")
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        if case .httpFailed(let code) = fpsError {
-            XCTAssertEqual(code, fakeHTTPStatus)
-        } else {
-            XCTFail("HTTP failure not reported with .httpFailed()")
-        }
     }
-    
-    func testRequestCertificateIOError() throws {
+
+    func testRequestCertificateIOError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
 
-        sessionManager.addDRMAsset(
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             throw FakeError()
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .because(_) = fpsError else {
+                XCTFail("I/O Failure should report a cause")
+                return
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .because(_) = fpsError else {
-            XCTFail("I/O Failure should report a cause")
-            return
-        }
-        
-        // If we make it here, we succeeded
     }
-    
-    func testRequestCertificateBlankWithSusStatusCode() throws {
+
+    func testRequestCertificateBlankWithSusStatusCode() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        // In this case, there's a successful response but no body
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate suspicious 200/OK should be treated as failure")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -381,55 +299,35 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, nil)
         }
-        
-        // Expected behavior: URLTask does something odd, requestCertificate returns error
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestCertificate(
-                playbackID: fakePlaybackId,
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                    requestFails.fulfill()
-                }
+
+        do {
+            _ = try await sessionManager.requestCertificate(playbackID: fakePlaybackId)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .unexpected(let message) = fpsError else {
+                XCTFail("An Unexpected error should be returned")
+                return
             }
+            XCTAssert(message == "No cert data with 200 OK response")
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .unexpected(let message) = fpsError else {
-            XCTFail("An Unexpected error should be returned")
-            return
-        }
-        XCTAssert(message == "No cert data with 200 OK response")
     }
     
-    func testRequestLicenseSuccess() throws {
+    func testRequestLicenseSuccess() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
-        // to be returned by call under test
-        let fakeLicense = "fake-license-binary-data".data(using: .utf8)
-        
-        sessionManager.addDRMAsset(
+        let fakeLicense = "fake-license-binary-data".data(using: .utf8)!
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestSuccess = XCTestExpectation(description: "request license successfully")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -437,41 +335,27 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, fakeLicense)
         }
-        
-        var requestResult: Result<Data, FairPlaySessionError>!
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                requestResult = result
-                requestSuccess.fulfill()
-            }
-        }
-        wait(for: [requestSuccess])
-        XCTAssertEqual(try requestResult.get(), fakeLicense)
+
+        let result = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+        XCTAssertEqual(result, fakeLicense)
     }
-    
-    func testLicenseRequestHttpError() throws {
+
+    func testLicenseRequestHttpError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        let fakeHTTPStatus = 500 // all codes are handled the same way, by failing
-        // real SPCs are opaque binary to us, the fake one can be whatever
+        let fakeHTTPStatus = 500
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
-        
-        sessionManager.addDRMAsset(
+
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -479,112 +363,64 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
-            // failed requests proxied from our drm vendor have response bodies with
-            //   base64 text, which we should treat as opaque (not parse or decode),
-            //   since we can't do anything with them and Cast logs them on the backend
             let errorBody = "failed request source text"
-            let errorData = errorBody.data(using: .utf8) // crashes if processed probably
-            return (
-                response,
-                errorData
-            )
+            let errorData = errorBody.data(using: .utf8)
+            return (response, errorData)
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            if case .httpFailed(let code) = fpsError {
+                XCTAssertEqual(code, fakeHTTPStatus)
+            } else {
+                XCTFail("HTTP failure not reported with .httpFailed()")
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        if case .httpFailed(let code) = fpsError {
-            XCTAssertEqual(code, fakeHTTPStatus)
-        } else {
-            XCTFail("HTTP failure not reported with .httpFailed()")
-        }
     }
-    
-    func testRequestLicenseIOError() throws {
+
+    func testRequestLicenseIOError() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
 
-        sessionManager.addDRMAsset(
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate successfully")
         MockURLProtocol.requestHandler = { request in
             throw FakeError()
         }
-        
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                do {
-                    let data = try result.get()
-                    XCTFail("failure should have been reported, but got \(String(describing: data))")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .because(_) = fpsError else {
+                XCTFail("I/O Failure should report a cause")
+                return
             }
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .because(_) = fpsError else {
-            XCTFail("I/O Failure should report a cause")
-            return
-        }
-        
-        // If we make it here, we succeeded
     }
-    
-    func testRequestLicenseBlankWithSusStatusCode() throws {
+
+    func testRequestLicenseBlankWithSusStatusCode() async throws {
         let fakeRootDomain = "custom.domain.com"
         let fakePlaybackId = "fake_playback_id"
         let fakePlaybackToken = "fake_playback_token"
         let fakeDrmToken = "fake_drm_token"
-        // In this case, there's a successful response but no body
         let fakeSpcData = "fake-spc-data".data(using: .utf8)!
 
-        sessionManager.addDRMAsset(
+        sessionManager.addOfflineDownloadDRMAsset(
             AVURLAsset(url: URL(string: "https://example.com/playlist.m3u8")!),
             playbackID: fakePlaybackId,
             options: .init(playbackToken: fakePlaybackToken, drmToken: fakeDrmToken),
             rootDomain: fakeRootDomain)
 
-        let requestFails = XCTestExpectation(description: "request certificate suspicious 200/OK should be treated as failure")
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -592,39 +428,19 @@ class FairPlaySessionManagerTests : XCTestCase {
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
             )!
-            
             return (response, nil)
         }
-        
-        // Expected behavior: URLTask does something odd, requestCertificate returns error
-        var reqError: Error?
-        targetQueue.async {
-            self.sessionManager.requestLicense(
-                spcData: fakeSpcData,
-                playbackID: fakePlaybackId,
-                offline: false
-            ) { result in
-                do {
-                    _ = try result.get()
-                    XCTFail("failure should have been reported")
-                } catch {
-                    reqError = error
-                }
-                requestFails.fulfill()
+
+        do {
+            _ = try await sessionManager.requestLicence(spcData: fakeSpcData, playbackID: fakePlaybackId)
+            XCTFail("failure should have been reported")
+        } catch let fpsError as FairPlaySessionError {
+            guard case .unexpected(let message) = fpsError else {
+                XCTFail("unexpected failure should be returned")
+                return
             }
+            XCTAssert(message == "No license data with 200 response")
         }
-        wait(for: [requestFails])
-        
-        guard let fpsError = reqError as? FairPlaySessionError else {
-            XCTFail("Request error was wrong type")
-            return
-        }
-        
-        guard case .unexpected(let message) = fpsError else {
-            XCTFail("unexpected failure should be returned")
-            return
-        }
-        XCTAssert(message == "No license data with 200 response")
     }
 
     func testPlaybackOptionsRegistered() throws {

--- a/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
@@ -12,7 +12,7 @@ class TestDRMAssetRegistry : DRMAssetRegistry {
     func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async {
     }
     
-    func hasOfflineDRMConfig(playbackID: String) -> Bool {
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool {
         return false
     }
     

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
@@ -26,7 +26,7 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
         )
     )
 
-    func requestCertificate(playbackID: String) async throws -> Data {
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data {
         if let fakeCert {
             return fakeCert
         } else if let certFailsWith {
@@ -36,7 +36,7 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
         }
     }
 
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data {
         if let fakeLicense {
             return fakeLicense
         } else if let licenseFailsWith {

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionCredentialClient.swift
@@ -47,26 +47,6 @@ class TestFairPlayStreamingSessionCredentialClient: FairPlayStreamingSessionCred
     }
 
 
-    func requestCertificate(playbackID: String, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        if let fakeCert = fakeCert {
-            requestCompletion(Result.success(fakeCert))
-        } else if let certFailsWith {
-            requestCompletion(Result.failure(certFailsWith))
-        } else {
-            requestCompletion(Result.failure(.unexpected(message: "No fake cert or error configured")))
-        }
-    }
-
-    func requestLicense(spcData: Data, playbackID: String, offline _: Bool, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        if let fakeLicense = fakeLicense {
-            requestCompletion(Result.success(fakeLicense))
-        } else if let licenseFailsWith {
-            requestCompletion(Result.failure(licenseFailsWith))
-        } else {
-            requestCompletion(Result.failure(.unexpected(message: "No fake license or error configured")))
-        }
-    }
-
     convenience init(fakeCert: Data, fakeLicense: Data) {
         self.init(fakeCert: fakeCert, fakeLicense: fakeLicense, certFailsWith: nil, licenseFailsWith: nil)
     }

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
@@ -46,8 +46,8 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
         await drmAssetRegistry.addOfflinePlayDRMAsset(urlAsset, playbackID: playbackID, keyData: keyData)
     }
 
-    func hasOfflineDRMConfig(playbackID: String) -> Bool {
-        drmAssetRegistry.hasOfflineDRMConfig(playbackID: playbackID)
+    func hasOfflineDRMConfig(playbackID: String) async -> Bool {
+        await drmAssetRegistry.hasOfflineDRMConfig(playbackID: playbackID)
     }
 
     func offlineKeyData(playbackID: String) -> Data? {

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
@@ -26,12 +26,12 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
         drmAssetRegistry.addDRMAsset(urlAsset, playbackID: playbackID, options: options, rootDomain: rootDomain)
     }
     
-    func requestCertificate(playbackID: String) async throws -> Data {
-        try await credentialClient.requestCertificate(playbackID: playbackID)
+    func requestCertificate(playbackID: String, offline: Bool) async throws -> Data {
+        try await credentialClient.requestCertificate(playbackID: playbackID, offline: offline)
     }
 
-    func requestLicence(spcData: Data, playbackID: String) async throws -> Data {
-        try await credentialClient.requestLicence(spcData: spcData, playbackID: playbackID)
+    func requestLicence(spcData: Data, playbackID: String, offline: Bool) async throws -> Data {
+        try await credentialClient.requestLicence(spcData: spcData, playbackID: playbackID, offline: offline)
     }
 
     func addOfflineDownloadDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
@@ -22,14 +22,6 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
         )
     )
 
-    func requestCertificate(playbackID: String, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        credentialClient.requestCertificate(playbackID: playbackID, completion: requestCompletion)
-    }
-
-    func requestLicense(spcData: Data, playbackID: String, offline: Bool, completion requestCompletion: @escaping (Result<Data, FairPlaySessionError>) -> Void) {
-        credentialClient.requestLicense(spcData: spcData, playbackID: playbackID, offline: offline, completion: requestCompletion)
-    }
-
     func addDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
         drmAssetRegistry.addDRMAsset(urlAsset, playbackID: playbackID, options: options, rootDomain: rootDomain)
     }


### PR DESCRIPTION
* Removes the old completion handler-based requestLicense and requestCertificate
* Refactors the async versions to use `URLSession.data(for:)` instead of using continuations
* Online `handleContentKeyRequest` method uses the new async way of doing things

There's no need to worry about cancellation in the ContentKeySessionDelegate methods, since it has no way to cancel anything. If a download task is canceled, this will be handled in other ways (ie, DownloadManager won't save content keys for removed records)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FairPlay DRM certificate/license fetching and content key request handling, so mistakes could break protected playback or offline key acquisition; changes are largely mechanical but involve concurrency and queue-safety adjustments.
> 
> **Overview**
> **FairPlay networking is now async-first.** The completion-handler variants of `requestCertificate`/`requestLicense` are removed, and `DefaultFairPlayStreamingSessionManager` now performs cert/license fetches via `URLSession.data(for:)` with async/throwing error propagation.
> 
> **Content key handling is refactored to async/await.** `ContentKeySessionDelegate` wraps key requests in `Task`s, makes `handleContentKeyRequest` async/throwing, and routes online vs offline flows by passing an explicit `offline: Bool` into cert/license requests; `hasOfflineDRMConfig` is now async to avoid unsafe cross-queue access.
> 
> **Tests updated accordingly.** FairPlay unit tests are migrated to async APIs, assertions are adjusted to new call signatures, and test helpers/protocols are updated to match the new async-only interfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230833f889d7fe01a0c46b7d65b12ab3a12da088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->