### PR TITLE
Releases/v1.6.0

### DIFF
--- a/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
@@ -11,7 +11,7 @@ public struct SemanticVersion {
     public static let major = 1
 
     /// Minor version component.
-    public static let minor = 5
+    public static let minor = 6
 
     /// Patch version component.
     public static let patch = 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a version constant bump only, affecting the reported `playerSoftwareVersion` string used by monitoring/telemetry but not runtime behavior.
> 
> **Overview**
> Bumps the SDK semantic version from `1.5.0` to `1.6.0` by updating `SemanticVersion.minor`, which in turn changes the `SemanticVersion.versionString` reported via monitoring metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04afefb7d5bd0a8dcecd4bfd6c3066f8e4ec3fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->