### PR TITLE
Releases/v1.6.1

### DIFF
--- a/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
@@ -14,7 +14,7 @@ public struct SemanticVersion {
     public static let minor = 6
 
     /// Patch version component.
-    public static let patch = 0
+    public static let patch = 1
 
     /// String form of the version number in the format X.Y.Z
     /// where X, Y, and Z are the major, minor, and patch


### PR DESCRIPTION
## Summary
- bump SDK semantic version from 1.6.0 to 1.6.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a patch-only version bump that only changes the reported `SemanticVersion.versionString` used in monitoring/telemetry metadata.
> 
> **Overview**
> Bumps the SDK semantic version from **1.6.0** to **1.6.1** by incrementing `SemanticVersion.patch`, updating the `SemanticVersion.versionString` propagated into monitoring `playerSoftwareVersion` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2212855db307f5017a20108b2a96b1c20045f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->