### PR TITLE
Releases/v1.7.0

### DIFF
--- a/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
@@ -11,10 +11,10 @@ public struct SemanticVersion {
     public static let major = 1
 
     /// Minor version component.
-    public static let minor = 6
+    public static let minor = 7
 
     /// Patch version component.
-    public static let patch = 1
+    public static let patch = 0
 
     /// String form of the version number in the format X.Y.Z
     /// where X, Y, and Z are the major, minor, and patch


### PR DESCRIPTION
## Summary
- bump SDK semantic version from 1.6.1 to 1.7.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only static version constants change; no runtime or API logic is modified.
> 
> **Overview**
> Bumps the public SDK version constants in `SemanticVersion` from **1.6.1** to **1.7.0** (`minor` 6→7, `patch` 1→0), so `versionString` reports the new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a7e16a83ea3af7fab616cc44a056ed77191870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->