### PR TITLE
NAT-386: Cache online FairPlay licenses

### DIFF
--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import AVFoundation
+import CryptoKit
 import Foundation
 import os
 
@@ -20,13 +21,21 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         _persistedKeyStore ?? MuxOfflineAccessManager.shared.manager
     }
 
+    private let _onlineLicenseCache: OnlineLicenseCaching?
+
+    private var onlineLicenseCache: OnlineLicenseCaching {
+        _onlineLicenseCache ?? OnlineDRMLicenseCache.shared
+    }
+
     init(
         sessionManager: SessionManager,
-        persistedKeyStore: PersistedKeyStore? = nil
+        persistedKeyStore: PersistedKeyStore? = nil,
+        onlineLicenseCache: OnlineLicenseCaching? = nil
     ) {
         self.sessionManager = sessionManager
         self.logger = sessionManager.logger
         self._persistedKeyStore = persistedKeyStore
+        self._onlineLicenseCache = onlineLicenseCache
     }
     
     // MARK: AVContentKeySessionDelegate implementation
@@ -205,22 +214,37 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             logger.debug("\(#function) Error: key SKD location missing playbackId [\(mediaPlaylistKeyURL.absoluteString)]")
             return
         }
-        
-        try await persistedKeyStore.savePersistedContentKey(
-            playbackID: playbackID,
-            identifier: requestIdentifierString,
-            contentKeyData: data
-        )
+
+        // Route the updated key to the right store: offline downloads persist
+        // to the on-disk key store; online assets update the short-term license cache.
+        if await sessionManager?.hasOfflineDRMConfig(playbackID: playbackID) == true {
+            try await persistedKeyStore.savePersistedContentKey(
+                playbackID: playbackID,
+                identifier: requestIdentifierString,
+                contentKeyData: data
+            )
+        } else {
+            let credentials = await sessionManager?.onlineDRMCredentials(playbackID: playbackID)
+            let fingerprint = Self.fingerprint(
+                forToken: credentials?.drmToken,
+                rootDomain: credentials?.rootDomain
+            )
+            await onlineLicenseCache.store(
+                playbackID: playbackID,
+                tokenFingerprint: fingerprint,
+                ckc: data
+            )
+        }
     }
     
     func handlePersistableContentKeyRequest(request: any KeyRequest) async throws {
         logger.trace("\(#function) called")
-        
+
         guard let sessionManager = self.sessionManager else {
             // could happen if recovering from media services crashing
             throw FairPlaySessionError.unexpected(message: "\(#function) called with terminated SessionManager")
         }
-        
+
         // for hls, "the identifier must be an NSURL that matches a key URI in the Media Playlist." from the docs
         guard let requestIdentifierString = request.identifier as? String,
               let mediaPlaylistKeyURL = URL(string: requestIdentifierString),
@@ -232,14 +256,45 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             )
             return
         }
-        
+
         guard let playbackID = parsePlaybackId(
             fromSkdLocation: mediaPlaylistKeyURL
         ) else {
             logger.debug("\(#function) Error: key SKD location missing playbackId [\(mediaPlaylistKeyURL.absoluteString)]")
             throw FairPlaySessionError.unexpected(message: "playbackID not present in key uri")
         }
-        
+
+        // An offline asset (downloading or playing back) uses the on-disk
+        // download key store and drm_token-claims-based expiration. An online
+        // asset uses the short-term online license cache.
+        if await sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
+            try await handleOfflinePersistableContentKeyRequest(
+                request: request,
+                sessionManager: sessionManager,
+                playbackID: playbackID,
+                requestIdentifierString: requestIdentifierString,
+                contentIdentifier: utfEncodedRequestIdentifierString
+            )
+        } else {
+            try await handleOnlineCachedContentKeyRequest(
+                request: request,
+                sessionManager: sessionManager,
+                playbackID: playbackID,
+                contentIdentifier: utfEncodedRequestIdentifierString
+            )
+        }
+    }
+
+    /// Offline download / playback path: serve a previously-persisted key if we
+    /// have one, otherwise fetch a persistable license and save it to the
+    /// download key store.
+    private func handleOfflinePersistableContentKeyRequest(
+        request: any KeyRequest,
+        sessionManager: SessionManager,
+        playbackID: String,
+        requestIdentifierString: String,
+        contentIdentifier: Data
+    ) async throws {
         // If we already have a persisted content key, use it (this is the offline playback path)
         if let persistedContentKey = try await persistedKeyStore.findPersistedContentKey(playbackID: playbackID) {
             // Transition to playDuration-based expiration on first offline playback
@@ -254,21 +309,82 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         let appCertData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: true)
         let spcData = try await request.makeStreamingContentKeyRequestData(
             forApp: appCertData,
-            contentIdentifier: utfEncodedRequestIdentifierString,
+            contentIdentifier: contentIdentifier,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
         )
         let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: true)
-        
+
         let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
         try await persistedKeyStore.savePersistedContentKey(
             playbackID: playbackID,
             identifier: requestIdentifierString,
             contentKeyData: persistableKey
         )
-        
+
         request.processContentKeyResponse(
             request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey)
         )
+    }
+
+    /// Online playback path: reuse a cached license if one is still
+    /// valid for the current `drm_token`, otherwise do the full handshake and
+    /// cache the resulting persistable license for next time.
+    private func handleOnlineCachedContentKeyRequest(
+        request: any KeyRequest,
+        sessionManager: SessionManager,
+        playbackID: String,
+        contentIdentifier: Data
+    ) async throws {
+        let credentials = await sessionManager.onlineDRMCredentials(playbackID: playbackID)
+        let fingerprint = Self.fingerprint(
+            forToken: credentials?.drmToken,
+            rootDomain: credentials?.rootDomain
+        )
+
+        // Cache hit: reuse the persisted license, no network round trip.
+        if let cachedLicense = await onlineLicenseCache.cachedLicense(
+            playbackID: playbackID,
+            tokenFingerprint: fingerprint
+        ) {
+            logger.debug("Using cached online license for \(playbackID, privacy: .public)")
+            request.processContentKeyResponse(
+                request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: cachedLicense)
+            )
+            return
+        }
+
+        // Cache miss: do the handshake and cache the persistable license.
+        let certData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: false)
+        let spcData = try await request.makeStreamingContentKeyRequestData(
+            forApp: certData,
+            contentIdentifier: contentIdentifier,
+            options: [AVContentKeyRequestProtocolVersionsKey: [1]]
+        )
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: false)
+
+        let persistableKey = try request.persistableContentKey(fromKeyVendorResponse: ckcData, options: nil)
+        await onlineLicenseCache.store(
+            playbackID: playbackID,
+            tokenFingerprint: fingerprint,
+            ckc: persistableKey
+        )
+
+        request.processContentKeyResponse(
+            request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey)
+        )
+    }
+
+    /// Stable fingerprint of the online DRM credentials so the cache invalidates
+    /// when the token or root domain changes. Deliberately excludes the `skd://`
+    /// key identifier (it can carry a per-session token, which would break
+    /// cross-session caching); multi-key assets are a non-goal.
+    static func fingerprint(forToken token: String?, rootDomain: String?) -> String {
+        guard let token else { return "no-token" }
+        let material = "\(rootDomain ?? "")\u{1f}\(token)"
+        guard let data = material.data(using: .utf8) else { return "no-token" }
+        return SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
     
     func handleContentKeyRequest(request: any KeyRequest) async throws {
@@ -304,36 +420,35 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             return
         }
         
-        var offlineRegistered: Bool = false
-        // Check for offline - if this is for offline, we trigger the persistable content key flow
-        if await sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
-            do {
-                try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
-                // no more processing for this key request. we'll get a delegate call with a persistable key request next
-                return
-            } catch {
-                // happens if playing airplay (according to example code). The proper response is to process as an online key
-                //  .. although using an 'offline' drm_token for playing an asset is technically not supported
-                offlineRegistered = true
-            }
+        let isOffline = await sessionManager.hasOfflineDRMConfig(playbackID: playbackID)
+
+        // Use the persistable-key flow for both offline (required) and online
+        // (so the license can be cached and reused). If it's unavailable
+        // (AirPlay, or a session with no storage directory), fall back below to
+        // a one-shot key.
+        do {
+            try request.respondByRequestingPersistableContentKeyRequestOnAnyOS()
+            // No more processing here; we'll get a persistable key request next.
+            return
+        } catch {
+            logger.debug("Persistable key request unavailable, using one-shot key: \(error.localizedDescription)")
         }
-        
-        // If we're not playing offline, do the handshake for an online key request
-        let certData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: offlineRegistered)
+
+        // Fallback: one-shot (ephemeral) key, no caching. Use the asset's
+        // offline token if it's an offline asset (not really supported, but
+        // preserves prior behavior), otherwise the online token.
+        let certData = try await sessionManager.requestCertificate(playbackID: playbackID, offline: isOffline)
         let spcData = try await request.makeStreamingContentKeyRequestData(
             forApp: certData,
             contentIdentifier: utfEncodedRequestIdentifierString,
             options: [AVContentKeyRequestProtocolVersionsKey: [1]]
         )
-        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: offlineRegistered)
-        
+        let ckcData = try await sessionManager.requestLicence(spcData: spcData, playbackID: playbackID, offline: isOffline)
+
         // Send CKC to CDM/ContentKeySession so we can finally play our content
         logger.debug("Submitting CKC to system")
-        let keyResponse = request.makeContentKeyResponse(
-            fairPlayStreamingKeyResponseData: ckcData
-        )
         request.processContentKeyResponse(
-            keyResponse
+            request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: ckcData)
         )
         logger.debug("Protected content now available for processing")
         // Done! no further interaction is required from us to play.

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -225,7 +225,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             )
         } else {
             let credentials = await sessionManager?.onlineDRMCredentials(playbackID: playbackID)
-            let fingerprint = Self.fingerprint(
+            let fingerprint = try Self.fingerprint(
                 forToken: credentials?.drmToken,
                 rootDomain: credentials?.rootDomain
             )
@@ -336,7 +336,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         contentIdentifier: Data
     ) async throws {
         let credentials = await sessionManager.onlineDRMCredentials(playbackID: playbackID)
-        let fingerprint = Self.fingerprint(
+        let fingerprint = try Self.fingerprint(
             forToken: credentials?.drmToken,
             rootDomain: credentials?.rootDomain
         )
@@ -378,26 +378,44 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
     /// when the token or root domain changes. Deliberately excludes the `skd://`
     /// key identifier (it can carry a per-session token, which would break
     /// cross-session caching); multi-key assets are a non-goal.
-    static func fingerprint(forToken token: String?, rootDomain: String?) -> String {
-        guard let token else { return "no-token" }
-        let material = "\(rootDomain ?? "")\u{1f}\(token)"
-        guard let data = material.data(using: .utf8) else { return "no-token" }
+    ///
+    /// Throws if the DRM token is missing — an exceptional state we don't want to
+    /// silently cache a bogus, unusable entry for. The error propagates up to the
+    /// `contentKeySession(_:didProvide:)` callbacks, which report it to the
+    /// system via `processContentKeyResponseError`.
+    static func fingerprint(forToken token: String?, rootDomain: String?) throws -> String {
+        guard let token else {
+            throw FairPlaySessionError.unexpected(message: "Missing DRM token; cannot fingerprint online credentials")
+        }
+        let data = Data("\(rootDomain ?? "")\u{1f}\(token)".utf8)
         return SHA256.hash(data: data)
             .map { String(format: "%02x", $0) }
             .joined()
     }
     
     /// A renewing request means the system no longer trusts the current key
-    /// (e.g. an expiring or obsolete lease), so the cached online license must
-    /// not be reused. Drop it first, then run the normal flow, which will
-    /// re-fetch a fresh license and re-cache it. For offline assets this is a
-    /// no-op (they don't use the online cache).
+    /// (e.g. an expiring or obsolete lease).
+    ///
+    /// - Online: drop the cached license so the normal flow re-fetches a fresh
+    ///   one and re-caches it.
+    /// - Offline: we can't renew (we don't persist the `drm_token`), so throw to
+    ///   notify the system via `processContentKeyResponseError` rather than hang
+    ///   or silently re-serve a stale key. The asset must be re-downloaded.
     func handleRenewingContentKeyRequest(request: any KeyRequest) async throws {
-        if let identifier = request.identifier as? String,
-           let keyURL = URL(string: identifier),
-           let playbackID = parsePlaybackId(fromSkdLocation: keyURL) {
-            await onlineLicenseCache.remove(playbackID: playbackID)
+        guard let identifier = request.identifier as? String,
+              let keyURL = URL(string: identifier),
+              let playbackID = parsePlaybackId(fromSkdLocation: keyURL) else {
+            try await handleContentKeyRequest(request: request)
+            return
         }
+
+        if await sessionManager?.hasOfflineDRMConfig(playbackID: playbackID) == true {
+            throw FairPlaySessionError.unexpected(
+                message: "Cannot renew an offline DRM license for \(playbackID); the asset must be re-downloaded"
+            )
+        }
+
+        await onlineLicenseCache.remove(playbackID: playbackID)
         try await handleContentKeyRequest(request: request)
     }
 

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -88,7 +88,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
         logger.trace("didProvide didProvideRenewingContentKeyRequest")
         Task {
             do {
-                try await handleContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
+                try await handleRenewingContentKeyRequest(request: DefaultKeyRequest(wrapping: keyRequest))
             } catch {
                 keyRequest.processContentKeyResponseError(error)
             }
@@ -387,6 +387,20 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             .joined()
     }
     
+    /// A renewing request means the system no longer trusts the current key
+    /// (e.g. an expiring or obsolete lease), so the cached online license must
+    /// not be reused. Drop it first, then run the normal flow, which will
+    /// re-fetch a fresh license and re-cache it. For offline assets this is a
+    /// no-op (they don't use the online cache).
+    func handleRenewingContentKeyRequest(request: any KeyRequest) async throws {
+        if let identifier = request.identifier as? String,
+           let keyURL = URL(string: identifier),
+           let playbackID = parsePlaybackId(fromSkdLocation: keyURL) {
+            await onlineLicenseCache.remove(playbackID: playbackID)
+        }
+        try await handleContentKeyRequest(request: request)
+    }
+
     func handleContentKeyRequest(request: any KeyRequest) async throws {
         logger.debug(
             "Called \(#function)"

--- a/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/FairPlaySessionManager.swift
@@ -33,6 +33,11 @@ protocol DRMAssetRegistry {
     func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async
     func hasOfflineDRMConfig(playbackID: String) async -> Bool
     func offlineKeyData(playbackID: String) async -> Data?
+    /// The `drm_token` and root domain tracked for an *online* DRM asset, if
+    /// any. Used to fingerprint the request so the online license cache can
+    /// invalidate when the app supplies a new token (or domain) for the same
+    /// playbackID.
+    func onlineDRMCredentials(playbackID: String) async -> (drmToken: String, rootDomain: String)?
 }
 
 // MARK: - FairPlayStreamingSessionManager
@@ -432,6 +437,23 @@ class DefaultFairPlayStreamingSessionManager<
                     return
                 }
                 continuation.resume(returning: offlinePlayLookup[playbackID])
+            }
+        }
+    }
+
+    func onlineDRMCredentials(playbackID: String) async -> (drmToken: String, rootDomain: String)? {
+        return await withCheckedContinuation { continuation in
+            queue.async { [logger, weak self] in
+                guard let self else {
+                    logger.warning("looked up online DRM credentials after cleanup")
+                    continuation.resume(returning: nil)
+                    return
+                }
+                if let config = onlineKeyConfigLookup[playbackID] {
+                    continuation.resume(returning: (config.options.drmToken, config.rootDomain))
+                } else {
+                    continuation.resume(returning: nil)
+                }
             }
         }
     }

--- a/Sources/MuxPlayerSwift/FairPlay/OnlineDRMLicenseCache.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/OnlineDRMLicenseCache.swift
@@ -1,0 +1,220 @@
+//
+//  OnlineDRMLicenseCache.swift
+//  MuxPlayerSwift
+//
+//  Short-term, on-disk cache of the persistable FairPlay licenses (CKCs) Mux
+//  issues for *online* playback, so repeat plays reuse the license instead of
+//  re-hitting the license server (a cost optimization).
+//
+//  Kept separate from the offline download key store: these aren't downloaded
+//  assets — they expire on a fixed short clock and live under Caches.
+//
+
+import Foundation
+import os
+
+// MARK: - OnlineLicenseCaching
+
+/// Abstraction over the online license cache so it can be mocked in tests.
+protocol OnlineLicenseCaching {
+    /// A cached license for the playbackID, if present, matching `tokenFingerprint` and unexpired.
+    func cachedLicense(playbackID: String, tokenFingerprint: String) async -> Data?
+    func store(playbackID: String, tokenFingerprint: String, ckc: Data) async
+    func remove(playbackID: String) async
+}
+
+// MARK: - OnlineDRMLicenseCache
+
+actor OnlineDRMLicenseCache: OnlineLicenseCaching {
+
+    static let shared = OnlineDRMLicenseCache()
+
+    /// Mux's online licenses last ~24h and FairPlay gives no way to read a CKC's
+    /// true expiry, so we treat a cached license as valid for this long — kept
+    /// just under 24h as a safety margin.
+    static let defaultTTL: TimeInterval = 23 * 60 * 60
+
+    private static let snapshotVersion = 1
+
+    private struct Entry: Codable {
+        let fileName: String
+        let tokenFingerprint: String
+        let fetchedAt: Date
+    }
+
+    private struct Snapshot: Codable {
+        let version: Int
+        let entries: [String: Entry]
+    }
+
+    #if DEBUG
+    private let logger = Logger(OSLog(subsystem: "com.mux.player", category: "CK"))
+    #else
+    private let logger = Logger(.disabled)
+    #endif
+
+    private let directory: URL?
+    private let ttl: TimeInterval
+    private let now: () -> Date
+
+    private var entries: [String: Entry]
+    private var loaded = false
+
+    /// `directory` and `now` are test injection points; `ttl` is how long a
+    /// cached license stays valid after fetch.
+    init(
+        directory: URL? = nil,
+        ttl: TimeInterval = OnlineDRMLicenseCache.defaultTTL,
+        now: @escaping () -> Date = { Date() }
+    ) {
+        self.directory = directory
+        self.ttl = ttl
+        self.now = now
+        self.entries = [:]
+    }
+
+    // MARK: OnlineLicenseCaching
+
+    func cachedLicense(playbackID: String, tokenFingerprint: String) async -> Data? {
+        loadIfNeeded()
+
+        guard let entry = entries[playbackID] else {
+            return nil
+        }
+
+        // A new token for the same playbackID means entitlements may have
+        // changed; treat the cached license as invalid and re-fetch.
+        guard entry.tokenFingerprint == tokenFingerprint else {
+            logger.debug("[Mux-Online-DRM] token changed for \(playbackID, privacy: .public); invalidating cached license")
+            discard(playbackID: playbackID)
+            return nil
+        }
+
+        guard now() < entry.fetchedAt.addingTimeInterval(ttl) else {
+            logger.debug("[Mux-Online-DRM] cached license expired for \(playbackID, privacy: .public)")
+            discard(playbackID: playbackID)
+            return nil
+        }
+
+        guard let dir = try? cacheDirectory() else { return nil }
+        let fileURL = dir.appendingPathComponent(entry.fileName)
+        guard let data = FileManager.default.contents(atPath: fileURL.path), !data.isEmpty else {
+            logger.warning("[Mux-Online-DRM] cached license file missing for \(playbackID, privacy: .public)")
+            discard(playbackID: playbackID)
+            return nil
+        }
+
+        logger.debug("[Mux-Online-DRM] serving cached license for \(playbackID, privacy: .public)")
+        return data
+    }
+
+    func store(playbackID: String, tokenFingerprint: String, ckc: Data) async {
+        loadIfNeeded()
+
+        guard let dir = try? cacheDirectory() else {
+            logger.warning("[Mux-Online-DRM] couldn't resolve cache directory; not caching \(playbackID, privacy: .public)")
+            return
+        }
+
+        let fileName = "\(sanitized(playbackID)).ckc"
+        let fileURL = dir.appendingPathComponent(fileName)
+        do {
+            try ckc.write(to: fileURL, options: .atomic)
+        } catch {
+            logger.warning("[Mux-Online-DRM] failed to write cached license for \(playbackID, privacy: .public): \(error.localizedDescription)")
+            return
+        }
+
+        entries[playbackID] = Entry(
+            fileName: fileName,
+            tokenFingerprint: tokenFingerprint,
+            fetchedAt: now()
+        )
+        persist()
+        logger.debug("[Mux-Online-DRM] cached license for \(playbackID, privacy: .public)")
+    }
+
+    func remove(playbackID: String) async {
+        loadIfNeeded()
+        discard(playbackID: playbackID)
+    }
+
+    // MARK: Internals
+
+    /// Drops any entries whose TTL has elapsed, deleting their files. Runs once
+    /// per process after the index is loaded, to keep disk usage bounded.
+    private func purgeExpired() {
+        let cutoff = now()
+        let expired = entries
+            .filter { cutoff >= $0.value.fetchedAt.addingTimeInterval(ttl) }
+            .map(\.key)
+        for playbackID in expired {
+            discard(playbackID: playbackID)
+        }
+    }
+
+    private func discard(playbackID: String) {
+        if let entry = entries.removeValue(forKey: playbackID),
+           let dir = try? cacheDirectory() {
+            let fileURL = dir.appendingPathComponent(entry.fileName)
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        persist()
+    }
+
+    private func sanitized(_ playbackID: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        return String(playbackID.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" })
+    }
+
+    private func cacheDirectory() throws -> URL {
+        if let directory {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            return directory
+        }
+        let fileManager = FileManager.default
+        let base = try fileManager.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        var dir = base.appendingPathComponent("mux-online-drm", isDirectory: true)
+        try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? dir.setResourceValues(values)
+        return dir
+    }
+
+    private func indexFileURL() throws -> URL {
+        try cacheDirectory().appendingPathComponent("index.plist", isDirectory: false)
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+        do {
+            let url = try indexFileURL()
+            guard FileManager.default.fileExists(atPath: url.path) else { return }
+            let data = try Data(contentsOf: url)
+            let snapshot = try PropertyListDecoder().decode(Snapshot.self, from: data)
+            entries = snapshot.entries
+        } catch {
+            logger.error("[Mux-Online-DRM] failed to load cache index: \(error.localizedDescription)")
+            entries = [:]
+        }
+        purgeExpired()
+    }
+
+    private func persist() {
+        do {
+            let encoder = PropertyListEncoder()
+            encoder.outputFormat = .binary
+            let data = try encoder.encode(Snapshot(version: Self.snapshotVersion, entries: entries))
+            try data.write(to: try indexFileURL(), options: .atomic)
+        } catch {
+            logger.error("[Mux-Online-DRM] failed to persist cache index: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
@@ -42,7 +42,7 @@ class PlayerSDK {
         )
         #else
         let sessionManager = DefaultFairPlayStreamingSessionManager(
-            contentKeySession: AVContentKeySession(keySystem: .fairPlayStreaming),
+            contentKeySession: PlayerSDK.makeFairPlayContentKeySession(),
             errorDispatcher: monitor
         )
         sessionManager.sessionDelegate = ContentKeySessionDelegate(
@@ -53,6 +53,49 @@ class PlayerSDK {
             monitor: monitor
         )
         #endif
+    }
+
+    /// Creates the FairPlay content key session, backed by a persistent on-disk
+    /// storage directory. The storage directory is required to vend
+    /// `AVPersistableContentKeyRequest`s, which we use both for offline DRM and
+    /// for short-term caching of online licenses. If the directory
+    /// can't be created we fall back to a session with no storage, which simply
+    /// disables persistable-key features rather than crashing.
+    static func makeFairPlayContentKeySession() -> AVContentKeySession {
+        if let storageURL = try? contentKeySessionStorageDirectory() {
+            return AVContentKeySession(
+                keySystem: .fairPlayStreaming,
+                storageDirectoryAt: storageURL
+            )
+        } else {
+            return AVContentKeySession(keySystem: .fairPlayStreaming)
+        }
+    }
+
+    /// On-disk directory used by `AVContentKeySession` for its persistable-key
+    /// bookkeeping. This is separate from where we store the CKC bytes
+    /// themselves (offline download keys live under `mux-offline`, online
+    /// cached licenses under the online license cache).
+    static func contentKeySessionStorageDirectory() throws -> URL {
+        let fileManager = FileManager.default
+        let base = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        var directory = base.appendingPathComponent(
+            "com.mux.player/content-key-session",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? directory.setResourceValues(values)
+        return directory
     }
 
     init(

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -478,6 +478,27 @@ class ContentKeySessionDelegateTests : XCTestCase {
         }
     }
 
+    func testRenewingKeyRequest_InvalidatesCacheThenRefetches() async throws {
+        // A renewal must not reuse the cached license: it should drop the cache
+        // entry and fall through to the (persistable) fetch path so a fresh
+        // license is obtained.
+        let token = "online-token"
+        testDRMAssetRegistry.onlineToken = token
+        let fingerprint = ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
+        mockOnlineCache.cached["fake-playback"] = ("stale-license".data(using: .utf8)!, fingerprint)
+
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handleRenewingContentKeyRequest(request: mockRequest)
+
+        XCTAssertEqual(mockOnlineCache.removedCalls, ["fake-playback"])
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "respondByPersistableContentKeyRequestOnAnyOS")
+        )
+    }
+
     // MARK: - handleContentKeyUpdated tests
 
     func testContentKeyUpdated_OfflineAsset_SavesToDownloadStore() async throws {

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -16,6 +16,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
     var testCredentialClient: TestFairPlayStreamingSessionCredentialClient!
     var testSessionManager: TestFairPlayStreamingSessionManager!
     var mockKeyStore: MockPersistedKeyStore!
+    var mockOnlineCache: MockOnlineLicenseCache!
 
     // object under test
     var contentKeySessionDelegate: ContentKeySessionDelegate<
@@ -40,6 +41,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         testCredentialClient = credentialClient
         testDRMAssetRegistry = TestDRMAssetRegistry()
         mockKeyStore = MockPersistedKeyStore()
+        mockOnlineCache = MockOnlineLicenseCache()
         testSessionManager = TestFairPlayStreamingSessionManager(
             credentialClient: testCredentialClient,
             drmAssetRegistry: testDRMAssetRegistry
@@ -47,7 +49,8 @@ class ContentKeySessionDelegateTests : XCTestCase {
 
         contentKeySessionDelegate = ContentKeySessionDelegate(
             sessionManager: testSessionManager,
-            persistedKeyStore: mockKeyStore
+            persistedKeyStore: mockKeyStore,
+            onlineLicenseCache: mockOnlineCache
         )
     }
 
@@ -59,6 +62,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
 
         testDRMAssetRegistry = TestDRMAssetRegistry()
         mockKeyStore = MockPersistedKeyStore()
+        mockOnlineCache = MockOnlineLicenseCache()
 
         testSessionManager = TestFairPlayStreamingSessionManager(
             credentialClient: testCredentialClient,
@@ -67,7 +71,8 @@ class ContentKeySessionDelegateTests : XCTestCase {
 
         contentKeySessionDelegate = ContentKeySessionDelegate(
             sessionManager: testSessionManager,
-            persistedKeyStore: mockKeyStore
+            persistedKeyStore: mockKeyStore,
+            onlineLicenseCache: mockOnlineCache
         )
     }
     
@@ -115,7 +120,53 @@ class ContentKeySessionDelegateTests : XCTestCase {
         )
     }
 
-    func testKeyRequestCertError() async {
+    // An online key request now defers to the persistable-key flow (so the
+    // resulting license can be cached). It should request a persistable
+    // key and do no further work on this request.
+    func testKeyRequest_DefersToPersistableForCaching() async throws {
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "respondByPersistableContentKeyRequestOnAnyOS")
+        )
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
+        )
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
+        )
+    }
+
+    // When the persistable request can't be made (e.g. AirPlay / no storage
+    // directory), we fall back to a one-shot online key.
+    func testKeyRequest_PersistableUnavailable_FallsBackToOneShot() async throws {
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+        mockRequest.persistableRequestError = FakeError()
+
+        try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
+
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
+        )
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
+        )
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")
+        )
+    }
+
+    func testKeyRequest_OneShotFallback_CertError() async {
         setUpWith(
             credentialClient: TestFairPlayStreamingSessionCredentialClient(
                 certFailsWith: .unexpected(message: "cert error")
@@ -124,6 +175,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
+        mockRequest.persistableRequestError = FakeError()
 
         do {
             try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
@@ -140,7 +192,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         }
     }
 
-    func testKeyRequestLicenseError() async {
+    func testKeyRequest_OneShotFallback_LicenseError() async {
         setUpWith(
             credentialClient: TestFairPlayStreamingSessionCredentialClient(
                 fakeCert: "fake-cert".data(using: .utf8)!,
@@ -150,6 +202,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
+        mockRequest.persistableRequestError = FakeError()
 
         do {
             try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
@@ -166,28 +219,6 @@ class ContentKeySessionDelegateTests : XCTestCase {
                 mockRequest.verifyNotCalled(funcName: "processContentKeyResponse")
             )
         }
-    }
-
-    func testKeyRequestHappyPath() async throws {
-        let mockRequest = MockKeyRequest(
-            fakeIdentifier: makeFakeSkdUrl(
-                fakePlaybackID: "fake-playback"
-            )
-        )
-
-        try await contentKeySessionDelegate.handleContentKeyRequest(request: mockRequest)
-
-        XCTAssertTrue(
-            mockRequest.verifyNotCalled(funcName: "processContentKeyResponseError")
-        )
-        XCTAssertTrue(
-            mockRequest.verifyWasCalled(
-                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
-            )
-        )
-        XCTAssertTrue(
-            mockRequest.verifyWasCalled(funcName: "processContentKeyResponse")
-        )
     }
 
     // MARK: - handlePersistableContentKeyRequest tests
@@ -239,6 +270,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
     }
 
     func testPersistableKeyRequest_ExistingPersistedKey_UsesItDirectly() async throws {
+        testDRMAssetRegistry.offlineConfigured = true
         let fakeKeyData = "persisted-key-data".data(using: .utf8)!
         mockKeyStore.persistedKeys["fake-playback"] = fakeKeyData
 
@@ -263,6 +295,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
     }
 
     func testPersistableKeyRequest_NoPersistedKey_FetchesAndSaves() async throws {
+        testDRMAssetRegistry.offlineConfigured = true
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
@@ -292,6 +325,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
                 certFailsWith: .unexpected(message: "cert error")
             )
         )
+        testDRMAssetRegistry.offlineConfigured = true
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
@@ -318,6 +352,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
                 licenseFailsWith: .unexpected(message: "license error")
             )
         )
+        testDRMAssetRegistry.offlineConfigured = true
         let mockRequest = MockKeyRequest(
             fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
         )
@@ -341,9 +376,112 @@ class ContentKeySessionDelegateTests : XCTestCase {
         }
     }
 
+    // MARK: - Online license caching
+
+    func testOnlinePersistableKeyRequest_CacheHit_UsesCachedLicenseNoNetwork() async throws {
+        let token = "online-token"
+        testDRMAssetRegistry.onlineToken = token
+        let fingerprint = ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
+        let cachedLicense = "cached-license".data(using: .utf8)!
+        mockOnlineCache.cached["fake-playback"] = (cachedLicense, fingerprint)
+
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+
+        // Served from cache: no cert/license network round trip, nothing stored.
+        XCTAssertTrue(mockRequest.verifyWasCalled(funcName: "processContentKeyResponse"))
+        XCTAssertTrue(
+            mockRequest.verifyNotCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
+        )
+        XCTAssertTrue(mockOnlineCache.storedCalls.isEmpty)
+    }
+
+    func testOnlinePersistableKeyRequest_CacheMiss_FetchesAndCaches() async throws {
+        let token = "online-token"
+        testDRMAssetRegistry.onlineToken = token
+
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
+        )
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(funcName: "persistableContentKey(fromKeyVendorResponse:options:)")
+        )
+        XCTAssertTrue(mockRequest.verifyWasCalled(funcName: "processContentKeyResponse"))
+
+        // Cached under the current token's fingerprint; not saved to the offline store.
+        XCTAssertEqual(mockOnlineCache.storedCalls.count, 1)
+        XCTAssertEqual(mockOnlineCache.storedCalls.first?.playbackID, "fake-playback")
+        XCTAssertEqual(
+            mockOnlineCache.storedCalls.first?.fingerprint,
+            ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
+        )
+        XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
+    }
+
+    func testOnlinePersistableKeyRequest_TokenChanged_Refetches() async throws {
+        // A stale entry cached under an old token must not be served when the app
+        // supplies a new token; we re-fetch and re-cache under the new one.
+        let oldFingerprint = ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: "old-token", rootDomain: "mux.com")
+        mockOnlineCache.cached["fake-playback"] = ("stale-license".data(using: .utf8)!, oldFingerprint)
+
+        let newToken = "new-token"
+        testDRMAssetRegistry.onlineToken = newToken
+
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+
+        XCTAssertTrue(
+            mockRequest.verifyWasCalled(
+                funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)"
+            )
+        )
+        XCTAssertEqual(mockOnlineCache.storedCalls.count, 1)
+        XCTAssertEqual(
+            mockOnlineCache.storedCalls.first?.fingerprint,
+            ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: newToken, rootDomain: "mux.com")
+        )
+    }
+
+    func testOnlinePersistableKeyRequest_CertError_Throws() async {
+        setUpWith(
+            credentialClient: TestFairPlayStreamingSessionCredentialClient(
+                certFailsWith: .unexpected(message: "cert error")
+            )
+        )
+        testDRMAssetRegistry.onlineToken = "online-token"
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        do {
+            try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(mockRequest.verifyNotCalled(funcName: "processContentKeyResponse"))
+            XCTAssertTrue(mockOnlineCache.storedCalls.isEmpty)
+        }
+    }
+
     // MARK: - handleContentKeyUpdated tests
 
-    func testContentKeyUpdated_HappyPath_SavesKey() async throws {
+    func testContentKeyUpdated_OfflineAsset_SavesToDownloadStore() async throws {
+        testDRMAssetRegistry.offlineConfigured = true
         let fakeKeyData = "updated-key-data".data(using: .utf8)!
         let keyIdentifier = makeFakeSkdUrl(fakePlaybackID: "fake-playback")
 
@@ -356,6 +494,29 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertEqual(mockKeyStore.savedKeys.first?.playbackID, "fake-playback")
         XCTAssertEqual(mockKeyStore.savedKeys.first?.identifier, keyIdentifier)
         XCTAssertEqual(mockKeyStore.savedKeys.first?.data, fakeKeyData)
+        XCTAssertTrue(mockOnlineCache.storedCalls.isEmpty)
+    }
+
+    func testContentKeyUpdated_OnlineAsset_UpdatesOnlineCache() async throws {
+        // Online asset (no offline config): an updated persistable key must go to
+        // the online license cache, not the offline download store.
+        testDRMAssetRegistry.onlineToken = "online-token"
+        let fakeKeyData = "updated-online-key".data(using: .utf8)!
+        let keyIdentifier = makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+
+        try await contentKeySessionDelegate.handleContentKeyUpdated(
+            keyIdentifier: keyIdentifier,
+            data: fakeKeyData
+        )
+
+        XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
+        XCTAssertEqual(mockOnlineCache.storedCalls.count, 1)
+        XCTAssertEqual(mockOnlineCache.storedCalls.first?.playbackID, "fake-playback")
+        XCTAssertEqual(mockOnlineCache.storedCalls.first?.ckc, fakeKeyData)
+        XCTAssertEqual(
+            mockOnlineCache.storedCalls.first?.fingerprint,
+            ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: "online-token", rootDomain: "mux.com")
+        )
     }
 
     func testContentKeyUpdated_NonStringIdentifier_DoesNotSave() async throws {

--- a/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/ContentKeySessionDelegateTests.swift
@@ -381,7 +381,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
     func testOnlinePersistableKeyRequest_CacheHit_UsesCachedLicenseNoNetwork() async throws {
         let token = "online-token"
         testDRMAssetRegistry.onlineToken = token
-        let fingerprint = ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
+        let fingerprint = try ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
         let cachedLicense = "cached-license".data(using: .utf8)!
         mockOnlineCache.cached["fake-playback"] = (cachedLicense, fingerprint)
 
@@ -426,7 +426,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertEqual(mockOnlineCache.storedCalls.first?.playbackID, "fake-playback")
         XCTAssertEqual(
             mockOnlineCache.storedCalls.first?.fingerprint,
-            ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
+            try ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
         )
         XCTAssertTrue(mockKeyStore.savedKeys.isEmpty)
     }
@@ -434,7 +434,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
     func testOnlinePersistableKeyRequest_TokenChanged_Refetches() async throws {
         // A stale entry cached under an old token must not be served when the app
         // supplies a new token; we re-fetch and re-cache under the new one.
-        let oldFingerprint = ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: "old-token", rootDomain: "mux.com")
+        let oldFingerprint = try ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: "old-token", rootDomain: "mux.com")
         mockOnlineCache.cached["fake-playback"] = ("stale-license".data(using: .utf8)!, oldFingerprint)
 
         let newToken = "new-token"
@@ -454,7 +454,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertEqual(mockOnlineCache.storedCalls.count, 1)
         XCTAssertEqual(
             mockOnlineCache.storedCalls.first?.fingerprint,
-            ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: newToken, rootDomain: "mux.com")
+            try ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: newToken, rootDomain: "mux.com")
         )
     }
 
@@ -484,7 +484,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         // license is obtained.
         let token = "online-token"
         testDRMAssetRegistry.onlineToken = token
-        let fingerprint = ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
+        let fingerprint = try ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: token, rootDomain: "mux.com")
         mockOnlineCache.cached["fake-playback"] = ("stale-license".data(using: .utf8)!, fingerprint)
 
         let mockRequest = MockKeyRequest(
@@ -497,6 +497,41 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertTrue(
             mockRequest.verifyWasCalled(funcName: "respondByPersistableContentKeyRequestOnAnyOS")
         )
+    }
+
+    func testRenewingKeyRequest_OfflineAsset_Throws() async {
+        // Offline licenses can't be renewed (we don't persist the drm_token), so
+        // a renewal should throw rather than no-op/hang, and must not touch the
+        // online cache.
+        testDRMAssetRegistry.offlineConfigured = true
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        do {
+            try await contentKeySessionDelegate.handleRenewingContentKeyRequest(request: mockRequest)
+            XCTFail("Expected renewing an offline asset to throw")
+        } catch {
+            XCTAssertTrue(mockOnlineCache.removedCalls.isEmpty)
+        }
+    }
+
+    func testOnlinePersistableKeyRequest_MissingToken_Throws() async {
+        // No online drm_token configured (onlineToken is nil by default) →
+        // fingerprinting throws, and we must not fetch or cache a bogus entry.
+        let mockRequest = MockKeyRequest(
+            fakeIdentifier: makeFakeSkdUrl(fakePlaybackID: "fake-playback")
+        )
+
+        do {
+            try await contentKeySessionDelegate.handlePersistableContentKeyRequest(request: mockRequest)
+            XCTFail("Expected missing DRM token to throw")
+        } catch {
+            XCTAssertTrue(mockOnlineCache.storedCalls.isEmpty)
+            XCTAssertTrue(
+                mockRequest.verifyNotCalled(funcName: "makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:)")
+            )
+        }
     }
 
     // MARK: - handleContentKeyUpdated tests
@@ -536,7 +571,7 @@ class ContentKeySessionDelegateTests : XCTestCase {
         XCTAssertEqual(mockOnlineCache.storedCalls.first?.ckc, fakeKeyData)
         XCTAssertEqual(
             mockOnlineCache.storedCalls.first?.fingerprint,
-            ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: "online-token", rootDomain: "mux.com")
+            try ContentKeySessionDelegate<TestFairPlayStreamingSessionManager>.fingerprint(forToken: "online-token", rootDomain: "mux.com")
         )
     }
 

--- a/Tests/MuxPlayerSwift/FairPlay/OnlineDRMLicenseCacheTests.swift
+++ b/Tests/MuxPlayerSwift/FairPlay/OnlineDRMLicenseCacheTests.swift
@@ -1,0 +1,87 @@
+//
+//  OnlineDRMLicenseCacheTests.swift
+//  MuxPlayerSwift
+//
+
+import XCTest
+@testable import MuxPlayerSwift
+
+final class OnlineDRMLicenseCacheTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mux-online-drm-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+    }
+
+    func testStoreThenHitReturnsLicense() async {
+        let cache = OnlineDRMLicenseCache(directory: tempDir)
+        let ckc = "license".data(using: .utf8)!
+
+        await cache.store(playbackID: "pb", tokenFingerprint: "fp", ckc: ckc)
+        let hit = await cache.cachedLicense(playbackID: "pb", tokenFingerprint: "fp")
+
+        XCTAssertEqual(hit, ckc)
+    }
+
+    func testFingerprintMismatchMisses() async {
+        let cache = OnlineDRMLicenseCache(directory: tempDir)
+        await cache.store(playbackID: "pb", tokenFingerprint: "fp", ckc: "x".data(using: .utf8)!)
+
+        let miss = await cache.cachedLicense(playbackID: "pb", tokenFingerprint: "different")
+
+        XCTAssertNil(miss)
+    }
+
+    func testWithinTTLHits() async {
+        var now = Date(timeIntervalSince1970: 1_000_000)
+        let cache = OnlineDRMLicenseCache(directory: tempDir, ttl: 100, now: { now })
+        let ckc = "x".data(using: .utf8)!
+        await cache.store(playbackID: "pb", tokenFingerprint: "fp", ckc: ckc)
+
+        now = now.addingTimeInterval(50) // still within TTL
+        let hit = await cache.cachedLicense(playbackID: "pb", tokenFingerprint: "fp")
+
+        XCTAssertEqual(hit, ckc)
+    }
+
+    func testExpiredEntryMisses() async {
+        var now = Date(timeIntervalSince1970: 1_000_000)
+        let cache = OnlineDRMLicenseCache(directory: tempDir, ttl: 100, now: { now })
+        await cache.store(playbackID: "pb", tokenFingerprint: "fp", ckc: "x".data(using: .utf8)!)
+
+        now = now.addingTimeInterval(101) // past TTL
+        let miss = await cache.cachedLicense(playbackID: "pb", tokenFingerprint: "fp")
+
+        XCTAssertNil(miss)
+    }
+
+    func testPersistsAcrossInstances() async {
+        let ckc = "license".data(using: .utf8)!
+        let cache1 = OnlineDRMLicenseCache(directory: tempDir)
+        await cache1.store(playbackID: "pb", tokenFingerprint: "fp", ckc: ckc)
+
+        // A fresh instance pointed at the same directory should load the entry.
+        let cache2 = OnlineDRMLicenseCache(directory: tempDir)
+        let hit = await cache2.cachedLicense(playbackID: "pb", tokenFingerprint: "fp")
+
+        XCTAssertEqual(hit, ckc)
+    }
+
+    func testRemoveDiscardsEntry() async {
+        let cache = OnlineDRMLicenseCache(directory: tempDir)
+        await cache.store(playbackID: "pb", tokenFingerprint: "fp", ckc: "x".data(using: .utf8)!)
+
+        await cache.remove(playbackID: "pb")
+        let miss = await cache.cachedLicense(playbackID: "pb", tokenFingerprint: "fp")
+
+        XCTAssertNil(miss)
+    }
+}

--- a/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockKeyRequest.swift
@@ -17,7 +17,12 @@ class MockKeyRequest : KeyRequest {
     
     private var fakeRequest: InnerRequest = []
     private let fakeIdentifier: Any
-    
+
+    /// When set, `respondByRequestingPersistableContentKeyRequestOnAnyOS()`
+    /// throws this error — simulating AirPlay / a session with no storage
+    /// directory, which forces the one-shot (ephemeral) key fallback.
+    var persistableRequestError: Error?
+
     // MARK: Protocol impl
     
     var identifier: Any? {
@@ -59,6 +64,9 @@ class MockKeyRequest : KeyRequest {
     
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws {
         fakeRequest.append(("respondByPersistableContentKeyRequestOnAnyOS", []))
+        if let persistableRequestError {
+            throw persistableRequestError
+        }
     }
     
     func persistableContentKey(fromKeyVendorResponse ckcData: Data, options: [String : Any]) {

--- a/Tests/MuxPlayerSwift/Helpers/MockOnlineLicenseCache.swift
+++ b/Tests/MuxPlayerSwift/Helpers/MockOnlineLicenseCache.swift
@@ -1,0 +1,30 @@
+import Foundation
+@testable import MuxPlayerSwift
+
+/// In-memory ``OnlineLicenseCaching`` for tests, with call recording.
+class MockOnlineLicenseCache: OnlineLicenseCaching {
+
+    /// Pre-seed to simulate cache hits: playbackID -> (license, fingerprint).
+    /// A lookup only hits when the fingerprint matches.
+    var cached: [String: (data: Data, fingerprint: String)] = [:]
+
+    var storedCalls: [(playbackID: String, fingerprint: String, ckc: Data)] = []
+    var removedCalls: [String] = []
+
+    func cachedLicense(playbackID: String, tokenFingerprint: String) async -> Data? {
+        guard let entry = cached[playbackID], entry.fingerprint == tokenFingerprint else {
+            return nil
+        }
+        return entry.data
+    }
+
+    func store(playbackID: String, tokenFingerprint: String, ckc: Data) async {
+        storedCalls.append((playbackID, tokenFingerprint, ckc))
+        cached[playbackID] = (ckc, tokenFingerprint)
+    }
+
+    func remove(playbackID: String) async {
+        removedCalls.append(playbackID)
+        cached[playbackID] = nil
+    }
+}

--- a/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestDRMAssetRegistry.swift
@@ -12,14 +12,27 @@ class TestDRMAssetRegistry : DRMAssetRegistry {
     func addOfflinePlayDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, keyData: Data) async {
     }
     
+    /// When true, `hasOfflineDRMConfig` reports the asset as offline (download /
+    /// offline playback). Defaults to false (online), matching most tests.
+    var offlineConfigured: Bool = false
+    /// The `drm_token` reported for online assets, used for cache fingerprinting.
+    var onlineToken: String?
+    /// The root domain reported for online assets.
+    var onlineRootDomain: String = "mux.com"
+
     func hasOfflineDRMConfig(playbackID: String) async -> Bool {
-        return false
+        return offlineConfigured
     }
-    
+
     func offlineKeyData(playbackID: String) async -> Data? {
         return nil
     }
-    
+
+    func onlineDRMCredentials(playbackID: String) async -> (drmToken: String, rootDomain: String)? {
+        guard let onlineToken else { return nil }
+        return (onlineToken, onlineRootDomain)
+    }
+
     var onDRMAsset: ((AVURLAsset, String, MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, String) -> Void)?
     func addDRMAsset(_ urlAsset: AVURLAsset, playbackID: String, options: MuxPlayerSwift.PlaybackOptions.DRMPlaybackOptions, rootDomain: String) {
         onDRMAsset?(urlAsset, playbackID, options, rootDomain)

--- a/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
+++ b/Tests/MuxPlayerSwift/Helpers/TestFairPlayStreamingSessionManager.swift
@@ -53,6 +53,10 @@ class TestFairPlayStreamingSessionManager : FairPlayStreamingSessionCredentialCl
     func offlineKeyData(playbackID: String) async -> Data? {
         await drmAssetRegistry.offlineKeyData(playbackID: playbackID)
     }
+
+    func onlineDRMCredentials(playbackID: String) async -> (drmToken: String, rootDomain: String)? {
+        await drmAssetRegistry.onlineDRMCredentials(playbackID: playbackID)
+    }
     
     init(credentialClient: any FairPlayStreamingSessionCredentialClient,
          drmAssetRegistry: any DRMAssetRegistry) {


### PR DESCRIPTION
## Why
Online DRM playback re-requested a FairPlay license from Mux's license server on **every** play. Mux already issues these as short-lived *persistable* licenses specifically so clients can cache them — we just weren't. Caching them eliminates repeat license-server / DRM-vendor round trips (a cost optimization) and speeds up time-to-first-frame.

## What
- **`OnlineDRMLicenseCache`** (actor): disk-backed cache under `Caches`, keyed by playback ID, ~23h TTL, invalidated when the `drm_token` or root domain changes. Excluded from backup; prunes expired entries on load.
- Online key requests now go through the **persistable-key flow**; `handlePersistableContentKeyRequest` and `didUpdatePersistableContentKey` branch **online** (license cache) vs **offline** (existing download key store).
- `AVContentKeySession` is now created with a **`storageDirectoryAt:`** (required to vend persistable keys; also benefits offline DRM). One-shot fallback preserved for AirPlay / sessions without a storage directory.
- **Internal only** — no public API change. All new logging is `DEBUG`-gated (silent in Release).

## Testing
**Unit:** 90 tests pass — cache hit/miss, token-change & TTL invalidation, disk persistence, online/offline routing, AirPlay one-shot fallback.

**On device** (physical iPhone, real FairPlay):
- Cold play → license fetched + cached
- Relaunch, same token → served from cache, **zero** license-server calls (video renders)
- New `drm_token` → cache invalidated, re-fetched
- TTL expiry (verified at a temporary 2-min TTL) → re-fetched after expiry
- Two assets (A→B→A) → independent per-asset caches, no cross-contamination
- **Offline DRM regression:** downloaded a DRM asset and played it in airplane mode — still works (the storage-directory change does not regress offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core FairPlay/DRM playback paths (key requests, renewals, session storage) and stores licenses on disk, though behavior is heavily tested and offline paths are largely preserved with explicit renewal failures.
> 
> **Overview**
> Adds **disk-backed caching of online FairPlay licenses** so repeat plays can skip Mux license-server round trips. New `OnlineDRMLicenseCache` stores persistable CKCs under Caches (~23h TTL), keyed by playback ID and invalidated when `drm_token` or root domain changes (SHA256 fingerprint).
> 
> **FairPlay key flow changes:** online playback now prefers the **persistable-key path** (same as offline) so licenses can be cached; `handlePersistableContentKeyRequest` and key-update callbacks **route online → license cache vs offline → existing download key store**. Renewing key requests **clear the online cache and re-fetch**; offline renewals **fail explicitly** (re-download required). When persistable keys are unavailable (e.g. AirPlay), behavior falls back to a **one-shot ephemeral key** without caching.
> 
> `AVContentKeySession` is created with **`storageDirectoryAt:`** when possible (needed for persistable keys); `FairPlaySessionManager` exposes **`onlineDRMCredentials`** for fingerprinting. **No public API changes**; tests cover cache hit/miss, TTL, token rotation, renewal, and routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1311d117650ff5bd7036bdbdb81116c197e2f4b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->