### PR TITLE
NAT-461: Improve online + offline DRM examples

### DIFF
--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/DRMPlayer.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/DRMPlayer.swift
@@ -9,15 +9,22 @@ import MuxPlayerSwift
 
 struct DRMPlayer: View {
     var body: some View {
-        DRMPlayerRepresentable(
-            playbackID: playbackID,
-            playbackToken: playbackToken,
-            drmToken: drmToken,
-            customDomain: customDomain
-        )
-        .ignoresSafeArea()
-        .background(.black)
-        .accessibilityIdentifier("DRMPlayerView")
+        // Play the protected stream when credentials are set; otherwise show
+        // setup instructions instead of failing silently. See DRMPlaybackCredentials.
+        if let credentials = DRMPlaybackCredentials.resolved {
+            DRMPlayerRepresentable(
+                playbackID: credentials.playbackID,
+                playbackToken: credentials.playbackToken,
+                drmToken: credentials.drmToken,
+                customDomain: credentials.customDomain
+            )
+            .ignoresSafeArea()
+            .background(.black)
+            .accessibilityIdentifier("DRMPlayerView")
+        } else {
+            DRMSetupInstructionsView()
+                .accessibilityIdentifier("DRMSetupInstructionsView")
+        }
     }
 }
 
@@ -27,22 +34,75 @@ struct DRMPlayer: View {
 
 // MARK: - Playback Configuration
 
-extension DRMPlayer {
-    private var playbackID: String {
-        ProcessInfo.processInfo.playbackID
-            ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
+/// Credentials for a Mux DRM (FairPlay) stream: a DRM-enabled `playbackID`, a
+/// `playbackToken` (authorizes playback) and a `drmToken` (authorizes the
+/// FairPlay license), both signed JWTs.
+///
+/// Empty by default — paste your own values below (don't commit real tokens), or
+/// set the PLAYBACK_ID / PLAYBACK_TOKEN / DRM_TOKEN scheme env vars, which win.
+enum DRMPlaybackCredentials {
+
+    // 👇 Paste your DRM-enabled playback ID and signed tokens here.
+    static let playbackID = ""
+    static let playbackToken = ""
+    static let drmToken = ""
+
+    /// Env vars take precedence over the constants. Returns `nil` if any field
+    /// is empty, so the screen can show setup instructions instead of failing.
+    static var resolved: Resolved? {
+        let id = ProcessInfo.processInfo.playbackID ?? playbackID
+        let playback = ProcessInfo.processInfo.playbackToken ?? playbackToken
+        let drm = ProcessInfo.processInfo.drmToken ?? drmToken
+
+        guard !id.isEmpty, !playback.isEmpty, !drm.isEmpty else {
+            return nil
+        }
+
+        return Resolved(
+            playbackID: id,
+            playbackToken: playback,
+            drmToken: drm,
+            customDomain: ProcessInfo.processInfo.customDomain
+        )
     }
 
-    private var playbackToken: String {
-        ProcessInfo.processInfo.playbackToken ?? ""
+    struct Resolved {
+        let playbackID: String
+        let playbackToken: String
+        let drmToken: String
+        let customDomain: String?
     }
+}
 
-    private var drmToken: String {
-        ProcessInfo.processInfo.drmToken ?? ""
-    }
+// MARK: - Setup Instructions
 
-    private var customDomain: String? {
-        ProcessInfo.processInfo.customDomain
+/// Shown when no DRM credentials are configured: explains what the screen does
+/// and how to enable it, instead of a blank screen or silent failure.
+private struct DRMSetupInstructionsView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("DRM Playback")
+                    .font(.title2.bold())
+
+                Text("This example plays a FairPlay (DRM) protected Mux stream. Nothing is playing because no DRM credentials are configured.")
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("To try it:")
+                        .font(.headline)
+                    Label("Use a DRM-enabled Mux playback ID.", systemImage: "1.circle")
+                    Label("Create a playback token and a DRM token, both signed with your Mux signing key.", systemImage: "2.circle")
+                    Label("Paste all three into the constants at the top of DRMPlayer.swift — or set the PLAYBACK_ID / PLAYBACK_TOKEN / DRM_TOKEN environment variables in the Xcode scheme.", systemImage: "3.circle")
+                }
+
+                Text("Once all three are set, this screen plays the protected stream automatically.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 }
 

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleOfflineDownloadManager.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample/Offline/ExampleOfflineDownloadManager.swift
@@ -44,7 +44,22 @@ final class ExampleOfflineDownloadManager: ObservableObject {
         ExampleAsset(
             playbackID: "wXqpSb3E1bI9xdr0100wIZ016j5WwP1HcfE",
             title: "Infrastructure Review"
-        )
+        ),
+
+        // The assets above are public, so they download without any tokens.
+        //
+        // To try OFFLINE DRM, uncomment the entry below and fill in your own
+        // values. Offline DRM needs a DRM-enabled playback ID plus two signed
+        // tokens — a playback token and a DRM token — both signed with your Mux
+        // signing key. With those, the FairPlay license is downloaded alongside
+        // the media so the asset plays back offline. Don't commit real tokens.
+        //
+        // ExampleAsset(
+        //     playbackID: "YOUR_DRM_PLAYBACK_ID",
+        //     title: "My DRM Asset (offline)",
+        //     playbackToken: "YOUR_PLAYBACK_TOKEN",
+        //     drmToken: "YOUR_DRM_TOKEN"
+        // ),
     ]
 
     /// Download states keyed by playback ID.

--- a/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExampleUITests/MuxPlayerSwiftExampleUITests.swift
+++ b/Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExampleUITests/MuxPlayerSwiftExampleUITests.swift
@@ -140,9 +140,11 @@ final class MuxPlayerSwiftExampleUITests: XCTestCase {
             application: application
         )
 
+        // No playback/DRM tokens are configured in CI, so the DRM screen shows
+        // its setup instructions instead of the player.
         try tapCell(
             cellIdentifier: "DRMPlayerRow",
-            waitFor: "DRMPlayerView",
+            waitFor: "DRMSetupInstructionsView",
             application: application
         )
     }


### PR DESCRIPTION
## What and Why
Make the example app's DRM screens actually demonstrate DRM.

- **Online:** drop the random fallback asset; credentials are empty by default and the screen shows setup instructions when they're missing instead of failing silently.
- **Offline:** add a commented-out DRM asset template to uncomment and fill in.

Verified on device with real DRM creds.

## Preview
<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 15 39 54" src="https://github.com/user-attachments/assets/f4407473-e873-48a0-8a55-a51fe05a0df7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app and UI-test changes only; no production SDK or auth logic is modified.
> 
> **Overview**
> The **online DRM** example no longer uses a hardcoded fallback playback ID or empty tokens that fail quietly. Credentials default to empty in `DRMPlaybackCredentials`, with scheme env vars overriding when set; if any field is missing, the screen shows **`DRMSetupInstructionsView`** instead of the player.
> 
> The **offline downloads** example adds a commented **`ExampleAsset`** template documenting playback + DRM tokens for offline FairPlay.
> 
> **UI tests** expect **`DRMSetupInstructionsView`** on the DRM row in CI (no tokens configured), not **`DRMPlayerView`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783797fe3b2d9aa4e14b02ec1984217741809bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->