### PR TITLE
Releases/v1.8.0

### DIFF
--- a/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
@@ -11,7 +11,7 @@ public struct SemanticVersion {
     public static let major = 1
 
     /// Minor version component.
-    public static let minor = 7
+    public static let minor = 8
 
     /// Patch version component.
     public static let patch = 0


### PR DESCRIPTION
## Summary
- bump SDK semantic version from 1.7.0 to 1.8.0

## Validation
- `xcodebuild -workspace .swiftpm/xcode/package.xcworkspace -scheme MuxPlayerSwift -destination generic/platform=iOS -derivedDataPath .build-derived-release build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in public version metadata with no runtime logic, API, or security impact.
> 
> **Overview**
> **Release version bump** for Mux Player Swift: public SDK version moves from **1.7.0** to **1.8.0** by changing `SemanticVersion.minor` from `7` to `8` in `SemanticVersion.swift`, which updates the computed `versionString` to `1.8.0`.
> 
> This matches the standard release flow (`releases/v1.8.0`) where the release PR only updates version metadata before tagging and publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7236b653c0e9b6ea4b24dc5cae102cb5739b4c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->