### PR TITLE
NAT-476: Restore tvOS build compatibility

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,9 @@ agents:
   queue: "macOS-Monterey-12-4"
 
 steps:
+  - command: "./scripts/build-tvos.sh"
+    label: ":tv: tvOS Compatibility Build Pass"
+  - wait
   - command: "./scripts/run-unit-tests.sh MuxPlayerSwift"
     label: ":xcode_simulator: Unit Test Pass"
   - wait
@@ -18,4 +21,3 @@ steps:
   - wait
   - command: "echo $BUILDKITE_HOOKS_PATH && ls -ls $BUILDKITE_HOOKS_PATH && buildkite-agent artifact download \"Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExample.ipa\" . && buildkite-agent artifact download \"Examples/MuxPlayerSwiftExample/MuxPlayerSwiftExampleUITests-Runner.ipa\" . && ./scripts/upload-example-application-to-sauce-labs.sh"
     label: ":saucelabs: UI Tests Pass on Real Device"
-

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ This guide describes the current maintainer release process for `mux-player-swif
    `main`.
 2. Create `releases/vX.Y.Z` from `origin/main`, update
    `Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift`, run the
-   iOS build, and open a release PR.
+   iOS build and tvOS compatibility build, and open a release PR.
 3. After the release PR is approved and merged, fetch `main`, verify the tag
    does not already exist, tag the merged `origin/main` commit as `vX.Y.Z`, and
    push the tag.
@@ -90,6 +90,7 @@ version.
 6. Validate the version bump.
    ```sh
    xcodebuild -scheme MuxPlayerSwift -destination generic/platform=iOS -derivedDataPath .build-derived-release build
+   ./scripts/build-tvos.sh
    ```
 
 7. Commit the version bump.

--- a/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
+++ b/Sources/MuxPlayerSwift/FairPlay/ContentKeySessionDelegate.swift
@@ -17,9 +17,11 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
 
     private let _persistedKeyStore: PersistedKeyStore?
 
+    #if os(iOS)
     private var persistedKeyStore: PersistedKeyStore {
         _persistedKeyStore ?? MuxOfflineAccessManager.shared.manager
     }
+    #endif
 
     private let _onlineLicenseCache: OnlineLicenseCaching?
 
@@ -215,26 +217,29 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             return
         }
 
-        // Route the updated key to the right store: offline downloads persist
-        // to the on-disk key store; online assets update the short-term license cache.
+        // Route updated offline keys to the on-disk store on iOS. tvOS only
+        // follows the online playback path.
+        #if os(iOS)
         if await sessionManager?.hasOfflineDRMConfig(playbackID: playbackID) == true {
             try await persistedKeyStore.savePersistedContentKey(
                 playbackID: playbackID,
                 identifier: requestIdentifierString,
                 contentKeyData: data
             )
-        } else {
-            let credentials = await sessionManager?.onlineDRMCredentials(playbackID: playbackID)
-            let fingerprint = try Self.fingerprint(
-                forToken: credentials?.drmToken,
-                rootDomain: credentials?.rootDomain
-            )
-            await onlineLicenseCache.store(
-                playbackID: playbackID,
-                tokenFingerprint: fingerprint,
-                ckc: data
-            )
+            return
         }
+        #endif
+
+        let credentials = await sessionManager?.onlineDRMCredentials(playbackID: playbackID)
+        let fingerprint = try Self.fingerprint(
+            forToken: credentials?.drmToken,
+            rootDomain: credentials?.rootDomain
+        )
+        await onlineLicenseCache.store(
+            playbackID: playbackID,
+            tokenFingerprint: fingerprint,
+            ckc: data
+        )
     }
     
     func handlePersistableContentKeyRequest(request: any KeyRequest) async throws {
@@ -264,9 +269,9 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             throw FairPlaySessionError.unexpected(message: "playbackID not present in key uri")
         }
 
-        // An offline asset (downloading or playing back) uses the on-disk
-        // download key store and drm_token-claims-based expiration. An online
-        // asset uses the short-term online license cache.
+        // An offline iOS asset uses the on-disk download key store. All online
+        // assets, including tvOS playback, follow the online request path.
+        #if os(iOS)
         if await sessionManager.hasOfflineDRMConfig(playbackID: playbackID) {
             try await handleOfflinePersistableContentKeyRequest(
                 request: request,
@@ -275,16 +280,19 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
                 requestIdentifierString: requestIdentifierString,
                 contentIdentifier: utfEncodedRequestIdentifierString
             )
-        } else {
-            try await handleOnlineCachedContentKeyRequest(
-                request: request,
-                sessionManager: sessionManager,
-                playbackID: playbackID,
-                contentIdentifier: utfEncodedRequestIdentifierString
-            )
+            return
         }
+        #endif
+
+        try await handleOnlineCachedContentKeyRequest(
+            request: request,
+            sessionManager: sessionManager,
+            playbackID: playbackID,
+            contentIdentifier: utfEncodedRequestIdentifierString
+        )
     }
 
+    #if os(iOS)
     /// Offline download / playback path: serve a previously-persisted key if we
     /// have one, otherwise fetch a persistable license and save it to the
     /// download key store.
@@ -325,6 +333,7 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             request.makeContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey)
         )
     }
+    #endif
 
     /// Online playback path: reuse a cached license if one is still
     /// valid for the current `drm_token`, otherwise do the full handshake and
@@ -409,11 +418,13 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             return
         }
 
+        #if os(iOS)
         if await sessionManager?.hasOfflineDRMConfig(playbackID: playbackID) == true {
             throw FairPlaySessionError.unexpected(
                 message: "Cannot renew an offline DRM license for \(playbackID); the asset must be re-downloaded"
             )
         }
+        #endif
 
         await onlineLicenseCache.remove(playbackID: playbackID)
         try await handleContentKeyRequest(request: request)
@@ -452,7 +463,11 @@ class ContentKeySessionDelegate<SessionManager: FairPlayStreamingSessionCredenti
             return
         }
         
+        #if os(iOS)
         let isOffline = await sessionManager.hasOfflineDRMConfig(playbackID: playbackID)
+        #else
+        let isOffline = false
+        #endif
 
         // Use the persistable-key flow for both offline (required) and online
         // (so the license can be cached and reused). If it's unavailable
@@ -579,6 +594,12 @@ struct DefaultKeyRequest : KeyRequest {
     func respondByRequestingPersistableContentKeyRequestOnAnyOS() throws {
         #if os(iOS)
         try self.request.respondByRequestingPersistableContentKeyRequestAndReturnError()
+        #elseif os(tvOS)
+        // Persistable online license caching on tvOS is deferred until the SDK
+        // officially supports and runtime-tests that platform.
+        throw FairPlaySessionError.unexpected(
+            message: "Persistable content keys are unavailable for tvOS compatibility"
+        )
         #else
         try self.request.respondByRequestingPersistableContentKeyRequest()
         #endif

--- a/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
+++ b/Sources/MuxPlayerSwift/Lifecycle/PlayerSDK.swift
@@ -186,6 +186,7 @@ class PlayerSDK {
         }
     }
     
+    #if os(iOS)
     func registerOfflineDRMAsset(
         _ urlAsset: AVURLAsset,
         playbackID: String,
@@ -201,6 +202,7 @@ class PlayerSDK {
             )
         }
     }
+    #endif
 
     func registerPlayerLayer(
         playerLayer: AVPlayerLayer,

--- a/Sources/MuxPlayerSwift/Offline/AnyPublisher+AsyncStream.swift
+++ b/Sources/MuxPlayerSwift/Offline/AnyPublisher+AsyncStream.swift
@@ -7,6 +7,8 @@
 
 import Combine
 
+#if os(iOS)
+
 extension AnyPublisher where Failure == any Error {
     func toAsyncThrowingStream() -> AsyncThrowingStream<Output, Failure> {
         AsyncThrowingStream { continuation in
@@ -30,3 +32,5 @@ extension AnyPublisher where Failure == any Error {
         }
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/Offline/DRMTokenClaims.swift
+++ b/Sources/MuxPlayerSwift/Offline/DRMTokenClaims.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+#if os(iOS)
+
 struct DRMTokenClaims {
     /// Seconds from license creation until expiration (when not yet played)
     let licenseExpiration: TimeInterval?
@@ -43,3 +45,5 @@ struct DRMTokenClaims {
         )
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadIndex.swift
@@ -8,6 +8,8 @@
 import Foundation
 import os
 
+#if os(iOS)
+
 // Stores a persistent index of downloaded media, along with sidecar data, DRM keys, etc
 actor DownloadIndex {
     
@@ -264,3 +266,5 @@ actor DownloadIndex {
         return try PropertyListDecoder().decode(IndexSnapshot.self, from: data)
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadManager.swift
@@ -10,6 +10,8 @@ import AVFoundation
 import Combine
 import os
 
+#if os(iOS)
+
 // MARK: - DownloadManager
 
 // Operations on Downloads, including tasks in-progress, key requests, key storage, and indexing downloaded
@@ -511,6 +513,8 @@ actor DownloadManager: PersistedKeyStore {
         detachEvents(for: playbackID)
     }
 }
+
+#endif
 
 protocol PersistedKeyStore {
     func findPersistedContentKey(playbackID: String) async throws -> Data?

--- a/Sources/MuxPlayerSwift/Offline/DownloadOptions+StoredAsset.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadOptions+StoredAsset.swift
@@ -6,6 +6,8 @@
 //
 import Foundation
 
+#if os(iOS)
+
 extension DownloadOptions {
     init(from storedAsset: StoredAsset) {
         self.readableTitle = storedAsset.readableTitle
@@ -18,3 +20,5 @@ extension DownloadOptions {
         }
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/Offline/DownloadTaskDelegate.swift
+++ b/Sources/MuxPlayerSwift/Offline/DownloadTaskDelegate.swift
@@ -9,6 +9,8 @@ import Foundation
 import AVFoundation
 import os
 
+#if os(iOS)
+
 class DownloadTaskDelegate: NSObject, AVAssetDownloadDelegate {
     #if DEBUG
     private let logger = Logger(OSLog(subsystem: "com.mux.player", category: "Mux-Offline"))
@@ -77,3 +79,5 @@ class DownloadTaskDelegate: NSObject, AVAssetDownloadDelegate {
         }
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/Offline/OfflineMediaSelectionHelper.swift
+++ b/Sources/MuxPlayerSwift/Offline/OfflineMediaSelectionHelper.swift
@@ -6,6 +6,8 @@
 import AVFoundation
 import Foundation
 
+#if os(iOS)
+
 enum OfflineMediaSelectionHelper {
     static func allMediaSelections(for asset: AVURLAsset) async throws -> [AVMediaSelection] {
         async let preferredSelection = asset.load(.preferredMediaSelection)
@@ -87,3 +89,5 @@ enum OfflineMediaSelectionHelper {
         return "\(option.displayName) [\(language)]"
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
+++ b/Sources/MuxPlayerSwift/Offline/StoredAsset.swift
@@ -14,6 +14,8 @@ enum ExpirationPhase: String, Codable {
     case playDuration
 }
 
+#if os(iOS)
+
 // internal DTO for our index of downloaded assets
 struct StoredAsset: Codable {
     let isComplete: Bool
@@ -100,3 +102,5 @@ extension StoredAsset: CustomDebugStringConvertible {
         return jsonString
     }
 }
+
+#endif

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/AssetStatus.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/AssetStatus.swift
@@ -9,6 +9,7 @@ import Foundation
 import AVFoundation
 
 /// The status of a downloaded asset
+@available(tvOS, unavailable, message: "Offline downloads are unavailable on tvOS.")
 public enum AssetStatus {
     /// The asset is ready to play
     case playable(asset: AVURLAsset)

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/DownloadEvent.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/DownloadEvent.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// Events emitted during a download
+@available(tvOS, unavailable, message: "Offline downloads are unavailable on tvOS.")
 public enum DownloadEvent {
     /// The download has started
     case started

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/DownloadOptions.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/DownloadOptions.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// Options for configuring a download
+@available(tvOS, unavailable, message: "Offline downloads are unavailable on tvOS.")
 public struct DownloadOptions {
     /// A human-readable title for the download
     public let readableTitle: String

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/DownloadedAsset.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/DownloadedAsset.swift
@@ -9,6 +9,7 @@ import Foundation
 import AVFoundation
 
 /// A downloaded video asset
+@available(tvOS, unavailable, message: "Offline downloads are unavailable on tvOS.")
 public struct DownloadedAsset {
     /// The Mux playback ID
     public let playbackID: String

--- a/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Offline/MuxOfflineAccessManager.swift
@@ -9,6 +9,8 @@ import Foundation
 import AVFoundation
 import os
 
+#if os(iOS)
+
 /// Manager for downloading and accessing Mux video content for offline playback
 public class MuxOfflineAccessManager {
     public static let shared = MuxOfflineAccessManager()
@@ -94,3 +96,12 @@ public class MuxOfflineAccessManager {
         PlayerSDK.shared.diagnosticsLogger.info("initializing MuxOfflineAccessManager")
     }
 }
+
+#elseif os(tvOS)
+
+/// Offline downloads are unavailable on tvOS because AVFoundation doesn't
+/// provide its asset-download APIs on that platform.
+@available(tvOS, unavailable, message: "Offline downloads are unavailable on tvOS.")
+public final class MuxOfflineAccessManager {}
+
+#endif

--- a/scripts/build-tvos.sh
+++ b/scripts/build-tvos.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Package.swift does not declare official tvOS support. Set the deployment
+# target explicitly to model a tvOS consumer and catch source-level regressions.
+xcodebuild -quiet build \
+    -scheme MuxPlayerSwift \
+    -destination "generic/platform=tvOS Simulator" \
+    TVOS_DEPLOYMENT_TARGET=15.0 \
+    CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
[NAT-476]

## Summary

- compile offline download implementation only on iOS
- mark public offline APIs unavailable on tvOS with a clear compiler message
- keep tvOS on the standard one-shot online DRM path while deferring persistable license caching
- add a tvOS 15 compatibility build to CI and the release checklist

## Context

Starting with v1.6.0, the offline download implementation introduced references to `AVAssetDownload*` APIs that are unavailable on tvOS, causing existing tvOS consumers to stop compiling.

This is intentionally limited to restoring the previous build compatibility reported in #101. It does not add tvOS to `Package.swift`, advertise official tvOS support, or add a tvOS example application. Broader runtime validation and official platform support will be handled separately.

Closes #101.

## Validation

- `./scripts/build-tvos.sh`
- generic iOS Simulator package build
- 93 iOS unit tests
- `shellcheck scripts/build-tvos.sh`
- `git diff --check`


[NAT-476]: https://mux1.atlassian.net/browse/NAT-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> FairPlay behavior on tvOS changes (no persistable/cached online keys until later work), while iOS offline paths are refactored behind compile guards; scope is large but aligned with restoring prior tvOS builds.
> 
> **Overview**
> Restores **tvOS compile compatibility** after v1.6.0 offline download work pulled in `AVAssetDownload*` APIs that tvOS does not expose.
> 
> **Offline downloads** are compiled only on iOS (`#if os(iOS)` across the Offline module and related `PlayerSDK` hooks). Public offline types and `MuxOfflineAccessManager` are marked `@available(tvOS, unavailable, …)` so tvOS consumers get a clear compiler message instead of link/API failures.
> 
> **FairPlay on tvOS** skips offline key persistence and persistable-key requests: `respondByRequestingPersistableContentKeyRequestOnAnyOS()` throws on tvOS so DRM falls through to the existing **one-shot** online key path; persistable online license caching on tvOS is explicitly deferred.
> 
> **CI / release**: adds `scripts/build-tvos.sh` (tvOS Simulator, deployment target 15) as the first Buildkite step and documents running it in `RELEASING.md` alongside the iOS build. This does not declare official tvOS support in `Package.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dde393cc2e1baf6207269b290aae5be3c42c0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->