### PR TITLE
Releases/v1.8.1

### DIFF
--- a/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
+++ b/Sources/MuxPlayerSwift/PublicAPI/Version/SemanticVersion.swift
@@ -14,7 +14,7 @@ public struct SemanticVersion {
     public static let minor = 8
 
     /// Patch version component.
-    public static let patch = 0
+    public static let patch = 1
 
     /// String form of the version number in the format X.Y.Z
     /// where X, Y, and Z are the major, minor, and patch


### PR DESCRIPTION
## Summary

- bump the SDK semantic version from 1.8.0 to 1.8.1
- prepare a patch release containing the tvOS compilation compatibility fix from #102

## Validation

- `xcodebuild -scheme MuxPlayerSwift -destination generic/platform=iOS -derivedDataPath .build-derived-release build`
- `./scripts/build-tvos.sh`

Both builds pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change to version metadata with no functional or security impact.
> 
> **Overview**
> Bumps the public SDK **patch** version in `SemanticVersion` from **1.8.0** to **1.8.1**, so `versionString` reports the new patch release.
> 
> This change is a release bookkeeping step for the v1.8.1 patch (including the tvOS compilation fix referenced in the PR description); no runtime behavior is altered beyond the reported version constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41936f314e0e8151c44a396de7cec37169469ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->